### PR TITLE
동호회 -  (club -members,managers) N:N 관계 테이블 생성 및 확인 테스트

### DIFF
--- a/api/src/main/java/com/hcs/domain/Club.java
+++ b/api/src/main/java/com/hcs/domain/Club.java
@@ -7,6 +7,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @Data : @Getter, @Setter, @ToString, @EqualsAndHashCode, @RequireArgsConstructor 를 한번에 설정함.
@@ -27,5 +29,10 @@ public class Club {
     private LocalDateTime createdAt;
     private String location;
     private String category;
+
+    private Set<User> members = new HashSet<>();
+    private int memberCount;
+    private Set<User> managers = new HashSet<>();
+    private int managerCount;
 
 }

--- a/api/src/main/java/com/hcs/domain/Club.java
+++ b/api/src/main/java/com/hcs/domain/Club.java
@@ -31,8 +31,8 @@ public class Club {
     private String category;
 
     private Set<User> members = new HashSet<>();
-    private int memberCount;
+    // private int memberCount; 성능 개선시 사용 예정
     private Set<User> managers = new HashSet<>();
-    private int managerCount;
+    // private int managerCount; 성능 개선시 사용 예정
 
 }

--- a/api/src/main/java/com/hcs/domain/Club.java
+++ b/api/src/main/java/com/hcs/domain/Club.java
@@ -31,8 +31,9 @@ public class Club {
     private String category;
 
     private Set<User> members = new HashSet<>();
+    private Set<User> managers = new HashSet<>(); // 관리자를 여러명 두어 최고, 서브 관리자로 role을 나눌 예정
+
     // private int memberCount; 성능 개선시 사용 예정
-    private Set<User> managers = new HashSet<>();
     // private int managerCount; 성능 개선시 사용 예정
 
 }

--- a/api/src/main/java/com/hcs/mapper/ClubMapper.java
+++ b/api/src/main/java/com/hcs/mapper/ClubMapper.java
@@ -4,7 +4,9 @@ import com.hcs.domain.Club;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-import java.util.List;
+/**
+ * @Param : mybatis 에서 sql 문장에 다수의 파라미터를 전달할 때 변수이름을 각각 지정해주기위해 사용한다.
+ */
 
 @Mapper
 public interface ClubMapper {

--- a/api/src/main/java/com/hcs/mapper/ClubMapper.java
+++ b/api/src/main/java/com/hcs/mapper/ClubMapper.java
@@ -2,13 +2,27 @@ package com.hcs.mapper;
 
 import com.hcs.domain.Club;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface ClubMapper {
 
     Club findByTitle(String title);
 
+    Club findById(Long id);
+
     void save(Club club);
 
     void delete(Long id);
+
+    Club findClubWithMembers(Long id);
+
+    Club findClubWithManagers(Long id);
+
+    void joinMemberById(@Param("clubId") Long clubId, @Param("memberId") Long userId);
+
+    void joinManagerById(@Param("clubId") Long clubId, @Param("managerId") Long userId);
+
 }

--- a/api/src/main/resources/mybatis-mapper/ClubMapper.xml
+++ b/api/src/main/resources/mybatis-mapper/ClubMapper.xml
@@ -21,4 +21,62 @@
         where HCS.Club.id = #{id}
     </delete>
 
+    <select id="findById" parameterType="Long" resultType="com.hcs.domain.Club">
+        select *
+        from Club
+        where id = #{id}
+    </select>
+
+    <insert id="joinMemberById" parameterType="map">
+        insert into club_members (clubId, memberId)
+        values(#{clubId}, #{memberId})
+    </insert>
+
+    <insert id="joinManagerById" parameterType="map">
+        insert into club_managers (clubId, managerId)
+        values(#{clubId}, #{managerId})
+    </insert>
+
+    <select id="findClubWithMembers" parameterType="Long" resultMap="clubWithMemberResult">
+        select c.*, u.id as userId , u.nickname as userNickname
+        from Club c
+        left join Club_members cm on c.id = cm.clubId
+        left join User u on cm.memberId = u.id
+        where c.id = #{id}
+       </select>
+
+    <resultMap id="clubWithMemberResult" type="com.hcs.domain.Club">
+        <id property="id" column="id"/>
+        <result property="title" column="title"/>
+        <result property="description" column="description"/>
+        <result property="createdAt" column="createdAt"/>
+        <result property="location" column="location"/>
+        <result property="category" column="category"/>
+        <collection property="members" javaType="java.util.HashSet" ofType="com.hcs.domain.User">
+            <id property="id" column="userId"/>
+            <result property="nickname" column="userNickname"/>
+        </collection>
+    </resultMap>
+
+    <select id="findClubWithManagers" parameterType="Long" resultMap="clubWithManagersResult">
+        select c.*, u.id as userId , u.nickname as userNickname
+        from Club c
+        left join Club_managers cm on c.id = cm.clubId
+        left join User u on cm.managerId = u.id
+        where c.id = #{id}
+       </select>
+
+    <resultMap id="clubWithManagersResult" type="com.hcs.domain.Club">
+        <id property="id" column="id"/>
+        <result property="title" column="title"/>
+        <result property="description" column="description"/>
+        <result property="createdAt" column="createdAt"/>
+        <result property="location" column="location"/>
+        <result property="category" column="category"/>
+        <collection property="managers" javaType="java.util.HashSet" ofType="com.hcs.domain.User">
+            <id property="id" column="userId"/>
+            <result property="nickname" column="userNickname"/>
+        </collection>
+    </resultMap>
+
 </mapper>

--- a/api/src/main/resources/sql/clubCreate.sql
+++ b/api/src/main/resources/sql/clubCreate.sql
@@ -6,6 +6,6 @@ create table Club
     createdAt                  datetime NOT NULL,
     location                   VARCHAR(20) NOT NULL,
     category                   VARCHAR(20) NOT NULL
-    managerCount               int DEFAULT 0,
-    memberCount                int DEFAULT 0
+    #managerCount               int DEFAULT 0,
+    #memberCount                int DEFAULT 0 성능 개선시 사용 예정
 )

--- a/api/src/main/resources/sql/clubCreate.sql
+++ b/api/src/main/resources/sql/clubCreate.sql
@@ -6,4 +6,6 @@ create table Club
     createdAt                  datetime NOT NULL,
     location                   VARCHAR(20) NOT NULL,
     category                   VARCHAR(20) NOT NULL
+    managerCount               int DEFAULT 0,
+    memberCount                int DEFAULT 0
 )

--- a/api/src/main/resources/sql/clubManagerCreate.sql
+++ b/api/src/main/resources/sql/clubManagerCreate.sql
@@ -1,0 +1,9 @@
+create table club_managers
+(
+    clubId              int NOT NULL,
+    managerId           int NOT NULL,
+
+    PRIMARY KEY (clubId, managerId),
+    FOREIGN KEY (clubId) REFERENCES Club (id),
+    FOREIGN KEY (managerId) REFERENCES User (id)
+)

--- a/api/src/main/resources/sql/clubMemberCreate.sql
+++ b/api/src/main/resources/sql/clubMemberCreate.sql
@@ -1,0 +1,9 @@
+create table club_members
+(
+    clubId              int NOT NULL,
+    memberId            int NOT NULL,
+
+    PRIMARY KEY (clubId, memberId),
+    FOREIGN KEY (clubId) REFERENCES Club (id),
+    FOREIGN KEY (memberId) REFERENCES User (id)
+)

--- a/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
@@ -2,6 +2,7 @@ package com.hcs.mapper;
 
 import com.hcs.domain.Club;
 import com.hcs.domain.User;
+import com.hcs.mapper.user.UserMapper;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
@@ -93,10 +93,11 @@ class ClubMapperTest {
 
             userMapper.save(user);
             User newUser = userMapper.findByEmail(username + "@gmail.com");
-            if (target.equals("member"))
+            if (target.equals("member")) {
                 clubMapper.joinMemberById(club.getId(), newUser.getId());
-            else if (target.equals("manager"))
+            } else if (target.equals("manager")) {
                 clubMapper.joinManagerById(club.getId(), newUser.getId());
+            }
         }
     }
 

--- a/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
@@ -1,6 +1,7 @@
 package com.hcs.mapper;
 
 import com.hcs.domain.Club;
+import com.hcs.domain.User;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,8 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -20,12 +21,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class ClubMapperTest {
     @Autowired
     ClubMapper clubMapper;
+    @Autowired
+    UserMapper userMapper;
 
     @DisplayName("ClubMapper - club db에 저장 및 찾기 테스트")
     @Test
     void saveAndFindByTitleTest() {
         Club club = Club.builder()
-                .title("AClub")
+                .title("testClub")
                 .location("Bucheon")
                 .category("test category")
                 .createdAt(LocalDateTime.now())
@@ -33,7 +36,7 @@ class ClubMapperTest {
 
         clubMapper.save(club);
 
-        Club aClub = clubMapper.findByTitle("AClub");
+        Club aClub = clubMapper.findByTitle("testClub");
         Club bClub = clubMapper.findByTitle("BClub");
         assertNotNull(aClub);
         assertNull(bClub);
@@ -43,17 +46,79 @@ class ClubMapperTest {
     @Test
     void deleteTest() {
         Club club = Club.builder()
-                .title("AClub")
+                .title("testDeleteClub")
                 .location("Bucheon")
                 .category("test category")
                 .createdAt(LocalDateTime.now())
                 .build();
 
         clubMapper.save(club);
-        Club aClub = clubMapper.findByTitle("AClub");
+        Club aClub = clubMapper.findByTitle("testDeleteClub");
         clubMapper.delete(aClub.getId());
 
-        Club newClub = clubMapper.findByTitle("AClub");
+        Club newClub = clubMapper.findByTitle("testDeleteClub");
         assertNull(newClub);
     }
+
+    @DisplayName("ClubMapper - club member 저장 및 가져오기")
+    @Test
+    void findMembersTest() {
+        Club club = Club.builder()
+                .title("testClub")
+                .location("Bucheon")
+                .category("test category")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        clubMapper.save(club);
+        Club testClub = clubMapper.findByTitle("testClub");
+
+        int memberSize = 3;
+        generateAndJoinClub(testClub, "member", memberSize);
+
+        Club aClubWithMembers = clubMapper.findClubWithMembers(testClub.getId());
+        assertNotNull(aClubWithMembers);
+        assertEquals(memberSize, aClubWithMembers.getMembers().size());
+
+    }
+
+    private void generateAndJoinClub(Club club, String target, int userSize) {
+        for (int i = 0; i < userSize; i++) {
+            String username = "testuser" + i;
+            User user = User.builder()
+                    .email(username + "@gmail.com")
+                    .nickname(username)
+                    .password(username + "pass").build();
+
+            userMapper.save(user);
+            User newUser = userMapper.findByEmail(username + "@gmail.com");
+            if (target.equals("member"))
+                clubMapper.joinMemberById(club.getId(), newUser.getId());
+            else if (target.equals("manager"))
+                clubMapper.joinManagerById(club.getId(), newUser.getId());
+        }
+    }
+
+    @DisplayName("ClubMapper - club manager 저장 및 가져오기")
+    @Test
+    void findManagersTest() {
+        Club club = Club.builder()
+                .title("testClub")
+                .location("Bucheon")
+                .category("test category")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        clubMapper.save(club);
+        Club testClub = clubMapper.findByTitle("testClub");
+
+        int managerSize = 5;
+        generateAndJoinClub(testClub, "manager", managerSize);
+
+        Club clubWithManagers = clubMapper.findClubWithManagers(testClub.getId());
+        assertNotNull(clubWithManagers);
+        assertEquals(managerSize, clubWithManagers.getManagers().size());
+
+    }
+
 }


### PR DESCRIPTION
- club domain에 members, managers 필드를 추가
- N:N 관계를 위한 club_members, club_managers 테이블 생성
- member,manager 에 대한 insert, select mapper 추가 및 테스트
현재는 manager와member각각 가져올수 있는 mapper 만 있지만, 추후 한꺼번에 가져올 수 있는  mapper 도 추가 예정입니다.
