### PR TITLE
addComment_functionalTest

### DIFF
--- a/api/src/main/java/com/hcs/controller/CommentController.java
+++ b/api/src/main/java/com/hcs/controller/CommentController.java
@@ -6,11 +6,11 @@ import com.hcs.dto.CommentDto;
 import com.hcs.dto.RespCommentDto;
 import com.hcs.service.CommentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import java.io.IOException;
@@ -36,7 +36,7 @@ public class CommentController {
                 .id(tradePostId)
                 .build();
 
-        int commentId = commentService.saveNewComment(commentDto, user, tradePost);
+        long commentId = commentService.saveNewComment(commentDto, user, tradePost);
         boolean success = false;
 
         if (commentId > 0) {

--- a/api/src/main/java/com/hcs/dto/CommentDto.java
+++ b/api/src/main/java/com/hcs/dto/CommentDto.java
@@ -1,6 +1,7 @@
 package com.hcs.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -8,6 +9,7 @@ import org.hibernate.validator.constraints.Length;
 import javax.validation.constraints.NotBlank;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class CommentDto {

--- a/api/src/main/java/com/hcs/dto/RespCommentDto.java
+++ b/api/src/main/java/com/hcs/dto/RespCommentDto.java
@@ -7,6 +7,6 @@ import lombok.Data;
 @AllArgsConstructor
 public class RespCommentDto {
 
-    private int commentId;
+    private long commentId;
     private boolean success;
 }

--- a/api/src/main/java/com/hcs/mapper/CommentMapper.java
+++ b/api/src/main/java/com/hcs/mapper/CommentMapper.java
@@ -8,7 +8,7 @@ public interface CommentMapper {
 
     Comment findById(long id);
 
-    int insertComment(Comment comment);
+    long insertComment(Comment comment);
 
     int deleteComment(long id);
 

--- a/api/src/main/java/com/hcs/service/CommentService.java
+++ b/api/src/main/java/com/hcs/service/CommentService.java
@@ -18,7 +18,7 @@ public class CommentService {
     private final CommentMapper commentMapper;
     private final ModelMapper modelMapper;
 
-    public int saveNewComment(@Valid CommentDto commentDto, User user, TradePost tradePost) {
+    public long saveNewComment(@Valid CommentDto commentDto, User user, TradePost tradePost) {
         Comment comment = modelMapper.map(commentDto, Comment.class);
         comment.setAuthor(user);
         comment.setTradePost(tradePost);

--- a/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
@@ -41,7 +41,7 @@ class CommentMapperTest {
 
         Comment testComment = makeTestComment();
 
-        int commentId = commentMapper.insertComment(testComment);
+        long commentId = commentMapper.insertComment(testComment);
 
         assertEquals(commentId, 1L);
     }

--- a/api/src/test/java/com/hcs/service/CommentServiceTest.java
+++ b/api/src/test/java/com/hcs/service/CommentServiceTest.java
@@ -1,0 +1,80 @@
+package com.hcs.service;
+
+import com.hcs.domain.Comment;
+import com.hcs.domain.TradePost;
+import com.hcs.domain.User;
+import com.hcs.dto.CommentDto;
+import com.hcs.mapper.CommentMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @ExtendWith : 테스트 클래스가 Mockito를 사용함을 의미함.
+ * @Mock : mock 객체를 생성함.
+ * @InjectMocks : 생성한 Mock객체를 주입하여 사용할 수 있도록 만든 객체.
+ * @BeforeEach : 테스트 케이스 시작 전에 먼저 실행되는 어노테이션.
+ */
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    CommentMapper commentMapper;
+
+    @Mock
+    ModelMapper modelMapper;
+
+    @InjectMocks
+    CommentService commentService;
+
+    // 테스트에 사용될 Dummy 데이터
+    User author;
+    TradePost tradePost;
+    CommentDto commentDto;
+
+    @BeforeEach
+    public void setUp() {
+        modelMapper = new ModelMapper();
+        commentService = new CommentService(commentMapper, modelMapper);
+
+        author = User.builder().build(); // Dummy 데이터
+        tradePost = TradePost.builder().build();
+        commentDto = CommentDto.builder().build();
+    }
+
+    @Test
+    @DisplayName("Comment 추가가 제대로 동작하는지 테스트")
+    void testSaveNewComment() {
+
+        // given
+        long testAuthorId = 31L;
+        long testTradePostId = 1L;
+        long newCommentId = 1L;
+
+        String commentContents = "테스트 댓글 입니다.";
+
+        author.setId(testAuthorId);
+        tradePost.setId(testTradePostId);
+        commentDto.setContents(commentContents);
+
+        Comment comment = Comment.builder()
+                .author(author)
+                .tradePost(tradePost)
+                .build();
+
+        // when
+        when(commentMapper.insertComment(comment)).thenReturn(newCommentId);
+
+        // then
+        assertThat(commentService.saveNewComment(commentDto, author, tradePost)).isEqualTo(newCommentId);
+    }
+}


### PR DESCRIPTION
1. 지난 PR 중 service `addComment()`, mapper `insertComment()` 기능에서 return 타입이 long이 아닌 int타입으로 되어 있었습니다.
   이 부분에 대한 수정이 이루어져 변경 파일들이 생기게 되었습니다. 죄송합니다😭
2. 해당 PR은 service `addComment()` 기능에 대한 단위테스트입니다.
 