### PR TITLE
create task for unit & integration test

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,1 +1,65 @@
 description = 'Hobby Community Service for my town'
+
+configurations {
+    integrationImplementation.extendsFrom(testImplementation)
+    integrationRuntimeOnly.extendsFrom(testRuntimeOnly)
+
+    unitRuntimeOnly.extendsFrom(testRuntimeOnly)
+    unitImplementation.extendsFrom(testImplementation)
+}
+
+sourceSets {
+    integration {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+        java {
+            srcDir file('src/test/integration/java')
+        }
+        resources {
+            srcDir file('src/test/integration/resources')
+        }
+    }
+
+    unit {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+        java {
+            srcDir file('src/test/unit/java')
+        }
+        resources {
+            srcDir file('src/test/unit/resources')
+        }
+    }
+}
+
+test {
+    testClassesDirs += sourceSets.integration.output.classesDirs
+    testClassesDirs += sourceSets.unit.output.classesDirs
+    classpath += sourceSets.integration.runtimeClasspath
+    classpath += sourceSets.unit.runtimeClasspath
+}
+
+task integration(type: Test) {
+    filter {
+        includeTestsMatching "com.hcs.controller.*"
+    }
+
+    useJUnitPlatform()
+
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED"
+    }
+}
+
+task unit(type: Test) {
+    filter {
+        includeTestsMatching "*Test"
+        excludeTestsMatching "com.hcs.controller.*"
+    }
+
+    useJUnitPlatform()
+
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED"
+    }
+}


### PR DESCRIPTION
unit & integration test를 위한 task를 만들었습니다.

1. 추후 테스트파일을 작성할 수 있도록 unit과 integration를 위한 논리적 단위인 sourceSets을 만들었습니다.

2. unit task, integration task
- 각 task 마다 테스트할 클래스를 이름과 폴더를 가지고 filtering 하여 생성하였습니다.