### PR TITLE
club - domain field "createdAt" 에 annotation 추가

### DIFF
--- a/api/src/main/java/com/hcs/domain/Club.java
+++ b/api/src/main/java/com/hcs/domain/Club.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -26,6 +28,7 @@ public class Club {
     private Long id;
     private String title;
     private String description;
+    @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime createdAt;
     private String location;
     private String category;


### PR DESCRIPTION
Club.java 도메인에 createdAt 필드가 db에 저장될때 나노 초 반올림이 되는것을 피하기위해 나노초 단위를 없애는 annotation을 추가했습니다.