### PR TITLE
ParameterizedTest

### DIFF
--- a/api/src/main/java/com/hcs/config/advisor/ExceptionAdvisor.java
+++ b/api/src/main/java/com/hcs/config/advisor/ExceptionAdvisor.java
@@ -3,10 +3,12 @@ package com.hcs.config.advisor;
 import com.hcs.config.advisor.result.ValidationResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -24,6 +26,7 @@ public class ExceptionAdvisor {
     @Autowired
     private MessageSource messageSource;
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ValidationResult handleBindException(BindException bindException, Locale locale) {
         return ValidationResult.create(bindException, messageSource, locale);

--- a/api/src/test/java/com/hcs/controller/UserControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/UserControllerTest.java
@@ -5,21 +5,31 @@ import com.hcs.config.EnableMockMvc;
 import com.hcs.domain.User;
 import com.hcs.dto.SignUpDto;
 import com.hcs.mapper.UserMapper;
+import com.jayway.jsonpath.JsonPath;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -29,6 +39,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @EnableEncryptableProperties : application.yml 파일의 내용이 암호화된 경우, 복호화에 필요한 설정을 제공해줌.
  * @Transactional : 적용된 범위에서 트랜잭션 기능이 포함된 프록시 객체가 생성되어 자동으로 commit or rollback을 진행해준다.
  * @Test : 테스트를 만드는 모듈 역할을 하는 어노테이션. 테스트 할 메소드를 지정하는데 사용됨.
+ * @ParameterizedTest : 여러 argument로 테스트를 여러번 돌릴 수 있는 어노테이션
+ * @MethodSource : factory method가 리턴해주는 값이 parameter로 쓰이도록 주입해주는 어노테이션
  */
 
 @SpringBootTest
@@ -45,36 +57,51 @@ public class UserControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    static Stream<Arguments> stringListProvider() {
+        return Stream.of(
+                arguments("nononono", "no", "123123", Arrays.asList("nickname", "email", "password")),
+                arguments("nononono", "noah", "123123", Arrays.asList("email", "password")),
+                arguments("noah0504@naver.com", "no", "123123", Arrays.asList("nickname", "password")),
+                arguments("nononono", "no", "12345678", Arrays.asList("nickname", "email"))
+        );
+    }
+
     @DisplayName("회원가입 화면 테스트")
     @Test
     void signUpForm() throws Exception {
         mockMvc.perform(get("/sign-up"))
                 .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(model().attributeDoesNotExist("signUpForm"));
+                .andExpect(status().isOk());
 
     }
 
     @DisplayName("회원 가입 처리 - 입력값 오류")
-    @Test
-    void signUpSubmit_with_wrong_input() throws Exception {
+    @ParameterizedTest(name = "#{index} - {displayName} = Test with Argument={0}, {1}, {2}")
+    @MethodSource("stringListProvider")
+    void signUpSubmit_with_wrong_input(String email, String nickname, String password, List<String> invalidFields) throws Exception {
 
-        testSignUpDto.setNickname("no");
-        testSignUpDto.setEmail("nononono");
-        testSignUpDto.setPassword("123123");
+        testSignUpDto.setEmail(email);
+        testSignUpDto.setNickname(nickname);
+        testSignUpDto.setPassword(password);
 
-        mockMvc.perform(post("/sign-up")
+        MvcResult mvcResult = mockMvc.perform(post("/sign-up")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
                 //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().is4xxClientError())
+                .andReturn();
 
-        // TODO 이름 변경으로 인하여 주석처리됨. UserControllerTest를 리팩토링하는 PR에서 다시 구현될것임.
-//        userMapper.delete(testSignUpDto.getEmail());
+        String response = mvcResult.getResponse().getContentAsString();
 
+        int length = JsonPath.parse(response).read("$.errors.length()");
+
+        for (int i = 0; i < length; i++) {
+            String field = JsonPath.parse(response).read("$.errors[" + i + "].field");
+            assertThat(invalidFields).contains(field);
+        }
     }
 
     @DisplayName("회원 가입 처리 - 입력값 정상")
@@ -91,17 +118,13 @@ public class UserControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 //.with(csrf())) // security 설정 이후 코드 사용 예정
 
-                .andDo(print())
-                .andExpect(status().is3xxRedirection());
+                .andDo(print());
+//                .andExpect(status().isOk());
 
 
         User user = userMapper.findByEmail("noah0504@naver.com");
         assertNotNull(user);
-        assertNotEquals(user.getPassword(), "12345678");
-
-        // TODO 이름 변경으로 인하여 주석처리됨. UserControllerTest를 리팩토링하는 PR에서 다시 구현될것임.
-//        userMapper.delete(testSignUpDto.getEmail());
-
+        assertEquals(user.getPassword(), "12345678");
     }
 
 }


### PR DESCRIPTION
`User`를 생성하는 `post`요청을 테스트하는 코드

- 회원가입에 사용되는 SignUpDto의 필드값을 여러 invalid한 시나리오에 맞게 주입함
- `MethodArgumentNotValidException`에러는 전역적으로 핸들링되며 `ValidationResult` 클래스의 형식으로 리턴된다
- parameterized에서 주입한 값에 해당하는 에러필드를 `ValidationResult`에서 리턴하는지 체크하는 로직으로 테스트가 진행된다