### PR TITLE
club controller - response json schema 에 clubUrl 추가 및 테스트

### DIFF
--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 /**
@@ -28,19 +29,23 @@ public class ClubController {
     private final HcsResponseManager responseManager;
 
     @PostMapping("/submit")
-    public HcsResponse createClub(@Valid @RequestBody ClubDto clubDto) {
+    public HcsResponse createClub(@Valid @RequestBody ClubDto clubDto, HttpServletRequest request) {
         //TODO : 로그인한 유저인지 검증 추가
 
         Club newClub = clubService.saveNewClub(clubDto);
-        return responseManager.submit.club(newClub.getId());
+        return responseManager.submit.club(newClub.getId(), getBaseUrl(request));
     }
 
     @GetMapping("/info")
-    public HcsResponse clubInfo(@RequestParam("clubId") Long id) {
+    public HcsResponse clubInfo(@RequestParam("clubId") Long id, HttpServletRequest request) {
         Club club = clubService.getClub(id);
-        return responseManager.info.club(club);
+        return responseManager.info.club(club, getBaseUrl(request));
     }
 
+    private String getBaseUrl(HttpServletRequest request) {
+        return request.getRequestURL().toString().replace(request.getRequestURI(), "") + "/";
+    }
+    
     //TODO : club list
 //    @GetMapping("/list")
 //    public HcsResponse clubList(@RequestParam("page")int page,@RequestParam("category") String category) {

--- a/api/src/main/java/com/hcs/dto/response/HcsResponseManager.java
+++ b/api/src/main/java/com/hcs/dto/response/HcsResponseManager.java
@@ -67,9 +67,9 @@ public class HcsResponseManager {
             return makeHcsResponse(hcs);
         }
 
-        public HcsResponse club(Club club) {
+        public HcsResponse club(Club club, String baseUrl) {
             ObjectNode hcs = objectMapper.createObjectNode();
-            ObjectNode item = clubInfo(club);
+            ObjectNode item = clubInfo(club, baseUrl);
 
             hcs.put("status", 200);
             hcs.set("item", item);
@@ -77,9 +77,10 @@ public class HcsResponseManager {
             return makeHcsResponse(hcs);
         }
 
-        private ObjectNode clubInfo(Club club) {
+        private ObjectNode clubInfo(Club club, String baseUrl) {
             ObjectNode item = objectMapper.createObjectNode();
             ObjectNode clubNode = objectMapper.valueToTree(club);
+            clubNode.put("clubUrl", baseUrl + "club/info?clubId=" + club.getId());
 
             //TODO : managers ,members 객체 추가
 
@@ -94,12 +95,12 @@ public class HcsResponseManager {
     @Component
     public class Submit {
 
-        public HcsResponse club(Long clubId) {
+        public HcsResponse club(Long clubId, String baseUrl) {
             ObjectNode hcs = objectMapper.createObjectNode();
             ObjectNode item = objectMapper.createObjectNode();
 
             item.put("clubId", clubId);
-            item.put("clubUrl", "club/Info?clubId=" + clubId.toString()); //TODO : base url 가져오기
+            item.put("clubUrl", baseUrl + "club/info?clubId=" + clubId.toString());
 
             hcs.put("status", 200);
             hcs.set("item", item);


### PR DESCRIPTION
club controller - response json schema 에 clubUrl 추가하고 테스트 코드를 추가했습니다.
아래에 동호회 정보 가져오기(GET /club/info) 요청을 보냈을 때 응답을 첨부했습니다.
```
{
	"HCS": {
		"status":200,
		"item": {
			"clubId":554,
			"club": {
				"title":"test table",
				"description":null,
				"createdAt":"2021-12-27T00:00:00",
				"location":"online",
				"category":"coding",
				"clubUrl":"https://localhost:8443/club/Info?clubId=554"
}}},"createdAt":"2021-12-27 03:46:22"}
```

원래 의도했던 schema 와 맞지 않는 부분(member, manager가 없는 부분)은 추후 추가할 예정입니다. 
