### PR TITLE
init STOMP

### DIFF
--- a/api/src/main/java/com/hcs/config/WsConfig.java
+++ b/api/src/main/java/com/hcs/config/WsConfig.java
@@ -1,0 +1,32 @@
+package com.hcs.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WsConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // socketJs 클라이언트가 WebSocket 핸드셰이크를 하기 위해 연결할 endpoint를 지정할 수 있다.
+        registry.addEndpoint("/").setAllowedOrigins("*").withSockJS();
+
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 메모리 기반 메시지 브로커가 해당 api를 구독하고 있는 클라이언트에게 메시지를 전달함
+        // to subscriber
+        registry.enableSimpleBroker("/sub");
+
+        // 클라이언트로부터 메시지를 받을 api의 prefix를 설정함
+        // publish
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+}

--- a/api/src/main/java/com/hcs/handler/WebSocketHandler.java
+++ b/api/src/main/java/com/hcs/handler/WebSocketHandler.java
@@ -1,0 +1,26 @@
+package com.hcs.handler;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class WebSocketHandler extends TextWebSocketHandler {
+
+    private Set<WebSocketSession> sessions = new ConcurrentHashMap().newKeySet();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        sessions.add(session);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        sessions.remove(session);
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
         implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-websocket'
         //implementation 'org.springframework.boot:spring-boot-starter-security'
         implementation 'org.springframework.boot:spring-boot-starter-jdbc'
         implementation 'org.springframework.boot:spring-boot-test-autoconfigure:2.6.0'


### PR DESCRIPTION
`spring-boot-starter-websocket`
- 양방향 통신 프로토콜인 `WebSocket`을 사용하여 채팅방을 구현하기 위한 의존성
- 클라이언트와 서버의 메시지 전송을 효율적으로 하기위해 `WebSocket` 프로토콜 위에서 동작하는 
`STOMP` 프로토콜을 사용할 것임

`STOMP` 프로토콜
- Simple Text Oriented Messaging Protocol
- 클라이언트와 서버가 전송할 메시지의 유형, 형식, 내용들을 정의한 매커니즘
- 해당 `Frame` 형식을 기반으로 전송됨
- <img width="200" alt="스크린샷 2021-12-27 오후 6 26 00" src="https://user-images.githubusercontent.com/58963724/147457213-5026a616-dab6-4aa0-99f4-7c51f9c0d635.png">

