### PR TITLE
ClubController - response 에  clubUrl 추가

### DIFF
--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 /**
@@ -28,19 +29,23 @@ public class ClubController {
     private final HcsResponseManager responseManager;
 
     @PostMapping("/submit")
-    public HcsResponse createClub(@Valid @RequestBody ClubDto clubDto) {
+    public HcsResponse createClub(@Valid @RequestBody ClubDto clubDto, HttpServletRequest request) {
         //TODO : 로그인한 유저인지 검증 추가
 
         Club newClub = clubService.saveNewClub(clubDto);
-        return responseManager.submit.club(newClub.getId());
+        return responseManager.submit.club(newClub.getId(), getBaseUrl(request));
     }
 
     @GetMapping("/info")
-    public HcsResponse clubInfo(@RequestParam("clubId") Long id) {
+    public HcsResponse clubInfo(@RequestParam("clubId") Long id, HttpServletRequest request) {
         Club club = clubService.getClub(id);
-        return responseManager.info.club(club);
+        return responseManager.info.club(club, getBaseUrl(request));
     }
 
+    private String getBaseUrl(HttpServletRequest request) {
+        return request.getRequestURL().toString().replace(request.getRequestURI(), "") + "/";
+    }
+    
     //TODO : club list
 //    @GetMapping("/list")
 //    public HcsResponse clubList(@RequestParam("page")int page,@RequestParam("category") String category) {

--- a/api/src/main/java/com/hcs/dto/response/HcsResponseManager.java
+++ b/api/src/main/java/com/hcs/dto/response/HcsResponseManager.java
@@ -80,7 +80,7 @@ public class HcsResponseManager {
         private ObjectNode clubInfo(Club club, String baseUrl) {
             ObjectNode item = objectMapper.createObjectNode();
             ObjectNode clubNode = objectMapper.valueToTree(club);
-            clubNode.put("clubUrl", baseUrl + "club/info?clubId=" + club.getId());
+            clubNode.put("clubUrl", baseUrl + "club/" + club.getId());
 
             //TODO : managers ,members 객체 추가
 
@@ -100,7 +100,7 @@ public class HcsResponseManager {
             ObjectNode item = objectMapper.createObjectNode();
 
             item.put("clubId", clubId);
-            item.put("clubUrl", baseUrl + "club/info?clubId=" + clubId.toString());
+            item.put("clubUrl", baseUrl + "club/" + clubId.toString());
 
             hcs.put("status", 200);
             hcs.set("item", item);

--- a/api/src/main/java/com/hcs/dto/response/HcsResponseManager.java
+++ b/api/src/main/java/com/hcs/dto/response/HcsResponseManager.java
@@ -67,9 +67,9 @@ public class HcsResponseManager {
             return makeHcsResponse(hcs);
         }
 
-        public HcsResponse club(Club club) {
+        public HcsResponse club(Club club, String baseUrl) {
             ObjectNode hcs = objectMapper.createObjectNode();
-            ObjectNode item = clubInfo(club);
+            ObjectNode item = clubInfo(club, baseUrl);
 
             hcs.put("status", 200);
             hcs.set("item", item);
@@ -77,9 +77,10 @@ public class HcsResponseManager {
             return makeHcsResponse(hcs);
         }
 
-        private ObjectNode clubInfo(Club club) {
+        private ObjectNode clubInfo(Club club, String baseUrl) {
             ObjectNode item = objectMapper.createObjectNode();
             ObjectNode clubNode = objectMapper.valueToTree(club);
+            clubNode.put("clubUrl", baseUrl + "club/info?clubId=" + club.getId());
 
             //TODO : managers ,members 객체 추가
 
@@ -94,12 +95,12 @@ public class HcsResponseManager {
     @Component
     public class Submit {
 
-        public HcsResponse club(Long clubId) {
+        public HcsResponse club(Long clubId, String baseUrl) {
             ObjectNode hcs = objectMapper.createObjectNode();
             ObjectNode item = objectMapper.createObjectNode();
 
             item.put("clubId", clubId);
-            item.put("clubUrl", "club/Info?clubId=" + clubId.toString()); //TODO : base url 가져오기
+            item.put("clubUrl", baseUrl + "club/info?clubId=" + clubId.toString());
 
             hcs.put("status", 200);
             hcs.set("item", item);

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -50,9 +50,9 @@ class ClubControllerTest {
         clubDto.setCreatedAt(LocalDateTime.now());
 
         mockMvc.perform(post("/club/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(clubDto))
-                        .accept(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(clubDto))
+                .accept(MediaType.APPLICATION_JSON))
                 //.with(csrf())) // security 설정 이후 코드 사용 예정
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -95,8 +95,8 @@ class ClubControllerTest {
         //when
 
         MvcResult mvcResult = mockMvc.perform(get("/club/info")
-                        .param("clubId", club.getId().toString())//올바른 id
-                        .accept(MediaType.APPLICATION_JSON))
+                .param("clubId", club.getId().toString())//올바른 id
+                .accept(MediaType.APPLICATION_JSON))
                 //then
                 .andExpect(status().is2xxSuccessful())
                 .andDo(print())
@@ -106,11 +106,8 @@ class ClubControllerTest {
                 .andExpect(jsonPath("$.HCS.item.club.location").value(club.getLocation()))
                 .andReturn();
 
-        String paramName = mvcResult.getRequest().getParameterNames().nextElement();
-        String paramValue = mvcResult.getRequest().getParameter(paramName);
-        String requestUrl = mvcResult.getRequest().getRequestURL()
-                + "?" + paramName
-                + "=" + paramValue; //params
+        //clubUrl 검증
+        String requestUrl = getBaseUrl(mvcResult) + "club/" + club.getId();
         String responseJsonClubUrl = JsonPath.parse(mvcResult.getResponse().getContentAsString()).read("$.HCS.item.club.clubUrl");
         assertEquals(requestUrl, responseJsonClubUrl);
 
@@ -132,6 +129,12 @@ class ClubControllerTest {
 //                .andExpect(status().is4xxClientError())
 //                .andExpect(jsonPath("message").value("존재하지 않는 club id 값입니다."));
 
+    }
+
+    private String getBaseUrl(MvcResult mvcResult) {
+        String url = mvcResult.getRequest().getRequestURL().toString();
+        String uri = mvcResult.getRequest().getRequestURI();
+        return mvcResult.getRequest().getRequestURL().toString().replace(mvcResult.getRequest().getRequestURI(), "") + "/";
     }
 
 }


### PR DESCRIPTION
**ClubController 에서 보내는 응답에 clubUrl 로 club 도메인 주소 추가**
아래는 동호회 정보 요청에 대한 응답 body 입니다.
```
{
	"HCS":{
		"status":200,
		"item":{
			"clubId":11,
			"club":{
				"title":"test title",
				"description":null,
				"createdAt":"2021-12-27T00:00:00",
				"location":"Mars",
				"category":"study",
				"clubUrl":"https://localhost:8443/club/11"
							}
						}
					},
	"createdAt":"2021-12-27 16:18:35"
}
```