### PR TITLE
setting redis

### DIFF
--- a/api/src/main/java/com/hcs/config/RedisConfig.java
+++ b/api/src/main/java/com/hcs/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.hcs.config;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        return template;
+    }
+
+}

--- a/api/src/main/java/com/hcs/config/RedisConfig.java
+++ b/api/src/main/java/com/hcs/config/RedisConfig.java
@@ -13,6 +13,10 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+/**
+ * @EnableRedisRepositories : Redis 관련 설정을 세팅하는 파일로 Spring이 redis 사용시 적용하도록 하도록 알려주게된다
+ */
+
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig {

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -20,6 +20,9 @@ spring:
       jdbc-url: "jdbc:mysql://localhost:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
       username: ENC(/vfTGzkQsvDmJGsLHCRGk8WaCVxqrAkS)
       password: ENC(/7M0dZ5y6e2xyeC2YPa3Jj7kqrJCYaCn)
+  redis:
+    host: localhost
+    port: 6379
 
 mybatis:
   mapper-locations: classpath:mybatis-mapper/*.xml

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ subprojects {
         implementation enforcedPlatform('org.springframework.boot:spring-boot-dependencies:2.5.6')
         implementation 'org.springframework.boot:spring-boot-starter'
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-websocket'


### PR DESCRIPTION
`noti`를 관리하는 Cache인 redis를 주입받음
- `spring-boot-starter-data-redis` 의존성 주입
- `RedisConfig` 파일 생성

redis 설치는 로컬호스트에서 도커로 설치하셔서 사용하시면 됩니다
- 설치방법
<img width="584" alt="스크린샷 2021-12-29 오전 1 14 12" src="https://user-images.githubusercontent.com/58963724/147585475-8af9f2a4-47d7-4306-9149-100b6e8280f1.png">

