### PR TITLE
Category db 테이블 생성 및 캐시 설정

### DIFF
--- a/api/src/main/java/com/hcs/Application.java
+++ b/api/src/main/java/com/hcs/Application.java
@@ -3,11 +3,13 @@ package com.hcs;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 /**
  * @SpringBootApplication : auto-configuration을 담당하는 어노테이션
+ * @EnableCaching : 캐시 관리 기능 활성화
  **/
-
+@EnableCaching
 @MapperScan(value = {"com.hcs.mapper"})
 @SpringBootApplication
 public class Application {
@@ -15,3 +17,6 @@ public class Application {
         SpringApplication.run(Application.class, args);
     }
 }
+
+
+

--- a/api/src/main/java/com/hcs/domain/Category.java
+++ b/api/src/main/java/com/hcs/domain/Category.java
@@ -1,0 +1,11 @@
+package com.hcs.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Category {
+    private final long id;
+    private final String name;
+}

--- a/api/src/main/java/com/hcs/mapper/CategoryMapper.java
+++ b/api/src/main/java/com/hcs/mapper/CategoryMapper.java
@@ -1,0 +1,11 @@
+package com.hcs.mapper;
+
+import com.hcs.domain.Category;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface CategoryMapper {
+    List<Category> selectAllCategory();
+}

--- a/api/src/main/java/com/hcs/service/CategoryService.java
+++ b/api/src/main/java/com/hcs/service/CategoryService.java
@@ -1,0 +1,25 @@
+package com.hcs.service;
+
+import com.hcs.domain.Category;
+import com.hcs.mapper.CategoryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * @Cacheable : 메소드의 결과를 캐시하고, 같은 key 값으로 메소드 실행 시 캐시된 데이터를 반환한다.
+ */
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryMapper categoryMapper;
+
+    @Cacheable(value = "categories")
+    public List<Category> getAllCategory() {
+        return categoryMapper.selectAllCategory();
+    }
+}

--- a/api/src/main/resources/mybatis-mapper/CategoryMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/CategoryMapperXml.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hcs.mapper.CategoryMapper">
+
+    <select id="selectAllCategory" resultType="com.hcs.domain.Category">
+        select *
+        from Category
+    </select>
+
+</mapper>

--- a/api/src/main/resources/sql/categoryCreateAndInsert.sql
+++ b/api/src/main/resources/sql/categoryCreateAndInsert.sql
@@ -1,0 +1,17 @@
+create table Category
+(
+    id      int AUTO_INCREMENT PRIMARY KEY COMMENT '카테고리 id key',
+    name    VARCHAR(15) NOT NULL
+)
+
+insert into Category (name) value ("sports");
+insert into Category (name) value ("reading");
+insert into Category (name) value ("music");
+insert into Category (name) value ("fashion");
+insert into Category (name) value ("beauty");
+insert into Category (name) value ("art");
+insert into Category (name) value ("crafts");
+insert into Category (name) value ("game");
+insert into Category (name) value ("study");
+insert into Category (name) value ("etc");
+

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-test-autoconfigure:2.6.0'
         implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.0'
         implementation 'org.modelmapper:modelmapper:2.4.4'
+        implementation 'org.springframework.boot:spring-boot-starter-cache'
 
         implementation 'org.hibernate:hibernate-core:5.6.0.Final'
         implementation 'org.projectlombok:lombok'


### PR DESCRIPTION
- category domain 객체 생성
- category  db table 생성 및 기본 카테고리 코드 insert
- 카테고리 캐싱을 위한 spring-boot-starter-cache 의존성 추가
api : https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/cache/annotation/Cacheable.html
참고글 : https://jeong-pro.tistory.com/170

- 카테고리 선정기준은 설문조사 사이트의 글을 참고해 동호회에 맞는 키워드를 임의로 골랐습니다.

```
스포츠
독서
음악
패션
뷰티
미술
공예
게임
공부
기타

sports
reading
music
fashion
beauty
art
crafts
game
study
etc
```

- 현재 String 타입으로 사용하고 있는 Club 도메인의 category 필드를 String 대신 category id를 저장하는 Long 타입으로 변경 예정입니다. 추후 pr 에서 domain 코드와 sql 코드 한꺼번에 수정하겠습니다.