### PR TITLE
createChatRoom

### DIFF
--- a/api/src/main/java/com/hcs/controller/ChatRoomController.java
+++ b/api/src/main/java/com/hcs/controller/ChatRoomController.java
@@ -1,28 +1,37 @@
 package com.hcs.controller;
 
 import com.hcs.domain.ChatRoom;
+import com.hcs.domain.TradePost;
+import com.hcs.domain.User;
 import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
+import com.hcs.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/chat")
 public class ChatRoomController {
 
-    //    private final ChatRoomService chatRoomService; // ChatRoomService 생성 이후로 활성화 할 것임.
-    private final SimpMessagingTemplate template;
     private final HcsResponseManager hcsResponseManager;
+    private final ChatRoomService chatRoomService;
+    private final SimpMessagingTemplate template;
 
     @PostMapping("/room/submit")
-    public HcsResponse createRoom() {
+    public HcsResponse createChatRoom(@RequestParam("userId") User buyer, @RequestParam(name = "tradePostId", required = false) TradePost saleTradePost) {
+
         ChatRoom newRoom = ChatRoom.create();
 
-//        chatRoomService.createChatRoom(newRoom);
+        if (saleTradePost == null) {
+            chatRoomService.createChatRoom(newRoom, buyer);
+        } else {
+            chatRoomService.createChatRoom(newRoom, buyer, saleTradePost.getAuthor());
+        }
 
         // 구매자에게 알람 날리기 : 구매자는 알람을 통해 자신의 기본 DM창으로 이동할 수 있음
 

--- a/api/src/main/java/com/hcs/domain/ChatRoom.java
+++ b/api/src/main/java/com/hcs/domain/ChatRoom.java
@@ -35,4 +35,8 @@ public class ChatRoom {
         room.setId(UUID.randomUUID().toString());
         return room;
     }
+
+    public void addMember(User user) {
+        this.members.add(user);
+    }
 }

--- a/api/src/main/java/com/hcs/service/ChatRoomService.java
+++ b/api/src/main/java/com/hcs/service/ChatRoomService.java
@@ -1,0 +1,35 @@
+package com.hcs.service;
+
+import com.hcs.domain.ChatRoom;
+import com.hcs.domain.User;
+import com.hcs.mapper.ChatRoomMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final ChatRoomMapper chatRoomMapper;
+
+    // '중고거래' 게시물에서 제공된 "판매자와 채팅" 버튼을 통해 방이 만들어지는 경우
+    public ChatRoom createChatRoom(ChatRoom newRoom, User buyer, User seller) {
+
+        newRoom.addMember(buyer);
+        newRoom.addMember(seller);
+
+        chatRoomMapper.insertChatRoom(newRoom);
+
+        return newRoom;
+    }
+
+    // 자신의 기본 DM창에서 방을 만드는 경우
+    public ChatRoom createChatRoom(ChatRoom newRoom, User curUser) {
+
+        newRoom.addMember(curUser);
+
+        chatRoomMapper.insertChatRoom(newRoom);
+
+        return newRoom;
+    }
+}


### PR DESCRIPTION
사용자가 채팅방을 만들 경우

1. 자신의 기본 `DM`창에서 채팅방을 만든다
2. 중고거래 게시글에 `판매자의 채팅` 버튼을 눌러 채팅방을 만든다

쿼리스트링으로 전달되는 속성값은 1, 2의 경우 모두 생성자는 받지만 판매자는 2번만 받는다
해당 경우에 대해 `@RequestParam`의 `required`속성을 사용하여 오버라이딩 효과를 보도록 코딩하였음

다음 PR에선
채팅방의 member들은 N:N 관계이므로 chatRoom_members 라는 테이블을 생성하여 관리할것임
(채팅방이 연관관계의 주인인 단방향으로 정의할것임)