### PR TITLE
ChatMessageController

### DIFF
--- a/api/src/main/java/com/hcs/controller/ChatMessageController.java
+++ b/api/src/main/java/com/hcs/controller/ChatMessageController.java
@@ -1,0 +1,31 @@
+package com.hcs.controller;
+
+import com.hcs.dto.ChatMessageDto;
+import com.hcs.dto.response.HcsResponseManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private final SimpMessagingTemplate template;
+    private final HcsResponseManager hcsResponseManager;
+//    private final ChatMessageService chatMessageService; // 생성한 이후에 활성화 할 것
+
+    @MessageMapping("/chat/message") // pub
+    public void message(ChatMessageDto message) {
+
+        // to subscriber
+        template.convertAndSend("/sub/chat/room?roomId=" + message.getRoomId(), message);
+
+//        ChatMessage newChat  = chatMessageService.createChatMessage(message);
+
+        // chatRoom의 chatMessages(Set자료구조)에 현재 글쓴 메시지 저장, members에 자신 추가
+        // /chat/room?roomId={roomId}로 redirect
+
+//		return hcsResponseManager.submit.ChatMessage(200, );
+    }
+}

--- a/api/src/main/java/com/hcs/dto/ChatMessageDto.java
+++ b/api/src/main/java/com/hcs/dto/ChatMessageDto.java
@@ -6,6 +6,7 @@ import lombok.Data;
 @Data
 @Builder
 public class ChatMessageDto {
+
     private String roomId;
     private long authorId;
     private String message;


### PR DESCRIPTION
`STOMP` 내장 `Broker`를 이용하여 subscriber에게 publishing하는 `chatMessageController`를 생성하였음

- `@MessageMapping`은 "/pub" 으로 시작하는 url을 client로부터 요청받을 경우임
- `SimpMessagingTemplate`는 STOMP Broker에게 Message를 전달하는 템플릿이며
- 첫 인자는 subscriber, 두번째 인자는 보낼 메시지이다
<img width="725" alt="스크린샷 2022-01-01 오전 3 06 37" src="https://user-images.githubusercontent.com/58963724/147835011-68797d4e-f509-4c7b-aa3a-e36cb1fcc391.png">

- `Message Handler` 단계에서 해당 메시지를 DB에 저장하는 로직은 다음PR에 작성할 것이다
 