### PR TITLE
tradePostDtoValidator

### DIFF
--- a/api/src/main/java/com/hcs/domain/TradePost.java
+++ b/api/src/main/java/com/hcs/domain/TradePost.java
@@ -1,6 +1,10 @@
 package com.hcs.domain;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Lob;
 import javax.persistence.Temporal;
@@ -8,7 +12,6 @@ import javax.persistence.TemporalType;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
-
 
 @Data
 @Builder
@@ -18,9 +21,8 @@ import java.util.Set;
 public class TradePost {
 
     @EqualsAndHashCode.Include
-    private Long id;
+    private long id;
 
-    private Long number;
     private User author;
     private String title;
     private String productStatus;
@@ -28,14 +30,15 @@ public class TradePost {
     private String description;
     @Lob
     private byte[] pictures;
-    private String appointmentLocation;
-    private Integer price;
-    private Integer views;
+    private String locationName;
+    private double lat;
+    private double lng;
+    private int price;
+    private int views;
 
     private Set<Comment> comments = new HashSet<>();
 
     private boolean salesStatus;
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime registerationTime;
-
 }

--- a/api/src/main/java/com/hcs/dto/TradePostDto.java
+++ b/api/src/main/java/com/hcs/dto/TradePostDto.java
@@ -7,8 +7,9 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 
 import javax.persistence.Lob;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 
 @Data
 @AllArgsConstructor
@@ -31,12 +32,18 @@ public class TradePostDto {
     @Lob
     private byte[] pictures;
 
+    @Length(min = 5, max = 100)
+    private String locationName;
+
+    @Min(-90)
+    @Max(90)
+    private double lat;
+
+    @Min(-180)
+    @Max(180)
+    private double lng;
+
     @NotBlank
     @Range(min = 1_000, max = 1_000_000, message = "1,000원 이상 1,000,000원 이하의 범위까지 가능합니다.")
     private Integer price;
-
-    @NotBlank
-    @Pattern(regexp = "^010[-](\\d{4})[-](\\d{4})$")
-    private String phoneNumber;
-
 }

--- a/api/src/main/java/com/hcs/mapper/TradePostMapper.java
+++ b/api/src/main/java/com/hcs/mapper/TradePostMapper.java
@@ -8,9 +8,7 @@ public interface TradePostMapper {
 
     TradePost findByTitle(String title);
 
-    Boolean existsByTitle(String title);
-
-    void save(TradePost tradePost);
+    void insert(TradePost tradePost);
 
     void delete(String title);
 

--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -1,18 +1,24 @@
 package com.hcs.service;
 
+import com.hcs.domain.TradePost;
 import com.hcs.dto.TradePostDto;
+import com.hcs.mapper.TradePostMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import javax.validation.Valid;
 
 @Service
 @RequiredArgsConstructor
 public class TradePostService {
 
-    public boolean saveTradePost(@Valid TradePostDto tradePostDto) {
+    private final TradePostMapper tradePostMapper;
+
+    public boolean saveTradePost(TradePostDto tradePostDto) {
         // TODO 중고게시글 저장하기
         return true;
+    }
+
+    public TradePost findByTitle(String title) {
+        return tradePostMapper.findByTitle(title);
     }
 
 }

--- a/api/src/main/java/com/hcs/validator/TradePostDtoValidator.java
+++ b/api/src/main/java/com/hcs/validator/TradePostDtoValidator.java
@@ -1,0 +1,36 @@
+package com.hcs.validator;
+
+import com.hcs.domain.TradePost;
+import com.hcs.dto.TradePostDto;
+import com.hcs.service.TradePostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class TradePostDtoValidator implements Validator {
+
+    private final TradePostService tradePostService;
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return clazz.isAssignableFrom(TradePostDto.class);
+    }
+
+    @Override
+    public void validate(Object object, Errors errors) {
+        TradePostDto tradePostDto = (TradePostDto) object;
+
+        TradePost tradePost = tradePostService.findByTitle(tradePostDto.getTitle());
+        Optional<TradePost> tradePostOptional = Optional.ofNullable(tradePost);
+
+        if (tradePostOptional.isPresent()) {
+            errors.rejectValue("title", "invalid.title", new Object[]{tradePostDto.getTitle()}, "이미 사용중인 글 제목입니다.");
+        }
+    }
+
+}

--- a/api/src/main/resources/mybatis-mapper/TradePostMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/TradePostMapperXml.xml
@@ -3,6 +3,7 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.hcs.mapper.TradePostMapper">
+    <cache/>
 
     <select id="findByTitle" parameterType="String" resultType="com.hcs.domain.TradePost">
         select *
@@ -10,17 +11,11 @@
         where title = #{title}
     </select>
 
-    <select id="existsByTitle" parameterType="String" resultType="boolean">
-        select IF(COUNT(*) = 1, 1, 0)
-        from TradePost
-        where title = #{title}
-    </select>
-
-    <insert id="save" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.TradePost">
-        insert into TradePost (number, authorId, title, productStatus, category, description,
-                               pictures, appointmentLocation, price, salesStatus, registerationTime)
-        values (#{number}, #{authorId}, #{title}, #{productStatus}, #{category}, #{description},
-                #{pictures}, #{appointmentLocation}, #{price}, #{salesStatus}, #{registerationTime})
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.TradePost">
+        insert into TradePost (authorId, title, productStatus, category, description,
+                               pictures, locationName, lat, lng, price, salesStatus, registerationTime)
+        values (#{authorId}, #{title}, #{productStatus}, #{category}, #{description},
+                #{pictures}, #{locationName}, #{lat}, #{lng}, #{price}, #{salesStatus}, #{registerationTime})
     </insert>
 
     <delete id="delete" parameterType="String">

--- a/api/src/main/resources/sql/tradePostCreate.sql
+++ b/api/src/main/resources/sql/tradePostCreate.sql
@@ -1,17 +1,18 @@
 create table TradePost
 (
-    id                  int AUTO_INCREMENT PRIMARY KEY COMMENT '중고거래 게시글 id key',
-    number              int          NOT NULL,
-    authorId            int          NOT NULL,
-    title               VARCHAR(30)  NOT NULL,
-    productStatus       VARCHAR(10)  NOT NULL,
-    category            VARCHAR(15)  NOT NULL,
-    description         VARCHAR(250) NOT NULL,
-    pictures            blob,
-    appointmentLocation VARCHAR(250),
-    price               int          NOT NULL,
-    salesStatus         boolean      NOT NULL,
-    registerationTime   datetime,
+    id                int AUTO_INCREMENT PRIMARY KEY COMMENT '중고거래 게시글 id key',
+    authorId          int          NOT NULL,
+    title             VARCHAR(30)  NOT NULL,
+    productStatus     VARCHAR(10)  NOT NULL,
+    category          VARCHAR(15)  NOT NULL,
+    description       VARCHAR(250) NOT NULL,
+    pictures          blob,
+    locationName      VARCHAR(100),
+    lat               DECIMAL(10, 8),
+    lng               DECIMAL(11, 8),
+    price             int          NOT NULL,
+    salesStatus       boolean      NOT NULL,
+    registerationTime datetime     NOT NULL,
 
     FOREIGN KEY (authorId) REFERENCES User (id) ON DELETE CASCADE
 )


### PR DESCRIPTION
`tradePostDtoValidator` 을 생성하였습니다. 생성하면서 domain 객체부터 DB 스키마까지 잘못된 부분을 수정하였습니다.

- `TradePost` domain class
  -  primitive 타입으로 변경
  - `number` 필드 삭제 (불필요함)
  -  중고 거래장소 이름과 장소의 좌표(위도, 경도) 필드 추가

- `TradePostDto` **Validation**
  - `locationName`의 길이 
  - `lat`, `lng`의 값 범위 체크

- `TradePostMapper` **Refactoring**
  - 이름 변경 save() -> insert()
  - existsBy~ method 삭제 (불필요함)

- `TradePostService` method 추가
   - `findByTitle()`

- `TradePostValidation`
   -  `title`로 같은 row인지 판별한 후에 insert 진행

- Table `TradePost` domain 변경에 따른 column 추가 및 수정
