### PR TITLE
Category - club domain 의 category 필드를 categoryId로 교체

### DIFF
--- a/api/src/main/java/com/hcs/domain/Category.java
+++ b/api/src/main/java/com/hcs/domain/Category.java
@@ -6,6 +6,18 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class Category {
+    /*  순서
+    sports
+    reading
+    music
+    fashion
+    beauty
+    art
+    crafts
+    game
+    study
+    etc
+     */
     private final long id;
     private final String name;
 }

--- a/api/src/main/java/com/hcs/domain/Club.java
+++ b/api/src/main/java/com/hcs/domain/Club.java
@@ -33,7 +33,7 @@ public class Club {
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime createdAt;
     private String location;
-    private String category;
+    private Long categoryId;
 
     @JsonIgnore
     private Set<User> members = new HashSet<>();

--- a/api/src/main/java/com/hcs/dto/ClubDto.java
+++ b/api/src/main/java/com/hcs/dto/ClubDto.java
@@ -24,7 +24,7 @@ public class ClubDto {
     @NotBlank
     private String location;
     @NotBlank
-    private Long categoryId;
+    private String category;
 
     public void setTitle(String title) {
         this.title = title.trim();

--- a/api/src/main/java/com/hcs/dto/ClubDto.java
+++ b/api/src/main/java/com/hcs/dto/ClubDto.java
@@ -24,7 +24,7 @@ public class ClubDto {
     @NotBlank
     private String location;
     @NotBlank
-    private String category;
+    private Long categoryId;
 
     public void setTitle(String title) {
         this.title = title.trim();

--- a/api/src/main/java/com/hcs/service/CategoryService.java
+++ b/api/src/main/java/com/hcs/service/CategoryService.java
@@ -22,4 +22,16 @@ public class CategoryService {
     public List<Category> getAllCategory() {
         return categoryMapper.selectAllCategory();
     }
+
+    @Cacheable(value = "categoryId", key = "#categoryName")
+    public Long getCategoryId(String categoryName) {
+        List<Category> categoryList = getAllCategory();
+        for (Category category : categoryList) {
+            if (category.getName().equals(categoryName)) {
+                return category.getId();
+            }
+        }
+        return null; //TODO : 에러 추가
+    }
+
 }

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -2,7 +2,6 @@ package com.hcs.service;
 
 import com.hcs.domain.Club;
 import com.hcs.dto.ClubDto;
-import com.hcs.mapper.CategoryMapper;
 import com.hcs.mapper.ClubMapper;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -2,6 +2,7 @@ package com.hcs.service;
 
 import com.hcs.domain.Club;
 import com.hcs.dto.ClubDto;
+import com.hcs.mapper.CategoryMapper;
 import com.hcs.mapper.ClubMapper;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -15,6 +16,7 @@ public class ClubService {
 
     private final ModelMapper modelMapper;
     private final ClubMapper clubMapper;
+    private final CategoryService categoryService;
 
     public Club saveNewClub(@Valid ClubDto clubDto) {
         Club club = modelMapper.map(clubDto, Club.class);

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -19,6 +19,7 @@ public class ClubService {
 
     public Club saveNewClub(@Valid ClubDto clubDto) {
         Club club = modelMapper.map(clubDto, Club.class);
+        club.setCategoryId(categoryService.getCategoryId(clubDto.getCategory()));
         try {
             clubMapper.insertClub(club);
         } catch (Exception e) {

--- a/api/src/main/resources/mybatis-mapper/ClubMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/ClubMapperXml.xml
@@ -17,8 +17,8 @@
     </select>
 
     <insert id="insertClub" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.Club">
-        insert into Club (title, description, createdAt, location, category)
-        values (#{title}, #{description}, #{createdAt}, #{location}, #{category})
+        insert into Club (title, description, createdAt, location, categoryId)
+        values (#{title}, #{description}, #{createdAt}, #{location}, #{categoryId})
     </insert>
 
     <delete id="deleteClubById" parameterType="Long">
@@ -51,7 +51,7 @@
         <result property="description" column="description"/>
         <result property="createdAt" column="createdAt"/>
         <result property="location" column="location"/>
-        <result property="category" column="category"/>
+        <result property="categoryId" column="categoryId"/>
         <collection property="members" javaType="java.util.HashSet" ofType="com.hcs.domain.User">
             <id property="id" column="userId"/>
             <result property="nickname" column="userNickname"/>
@@ -72,7 +72,7 @@
         <result property="description" column="description"/>
         <result property="createdAt" column="createdAt"/>
         <result property="location" column="location"/>
-        <result property="category" column="category"/>
+        <result property="categoryId" column="categoryId"/>
         <collection property="managers" javaType="java.util.HashSet" ofType="com.hcs.domain.User">
             <id property="id" column="userId"/>
             <result property="nickname" column="userNickname"/>

--- a/api/src/main/resources/sql/clubCreate.sql
+++ b/api/src/main/resources/sql/clubCreate.sql
@@ -5,7 +5,7 @@ create table Club
     description                VARCHAR(50),
     createdAt                  datetime NOT NULL,
     location                   VARCHAR(20) NOT NULL,
-    category                   VARCHAR(20) NOT NULL
+    categoryId                 int NOT NULL
     #managerCount               int DEFAULT 0,
     #memberCount                int DEFAULT 0 성능 개선시 사용 예정
 )

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -45,7 +45,7 @@ class ClubControllerTest {
     void createClub_with_correct_input() throws Exception {
         clubDto.setTitle("새마을농구동호회");
         clubDto.setDescription("농구하고싶은사람 모여라");
-        clubDto.setCategoryId(1L);
+        clubDto.setCategory("sports");
         clubDto.setLocation("Bucheon");
         clubDto.setCreatedAt(LocalDateTime.now());
 

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -45,7 +45,7 @@ class ClubControllerTest {
     void createClub_with_correct_input() throws Exception {
         clubDto.setTitle("새마을농구동호회");
         clubDto.setDescription("농구하고싶은사람 모여라");
-        clubDto.setCategory("스포츠/농구");
+        clubDto.setCategoryId(1L);
         clubDto.setLocation("Bucheon");
         clubDto.setCreatedAt(LocalDateTime.now());
 
@@ -87,7 +87,7 @@ class ClubControllerTest {
         Club club = Club.builder()
                 .title("testClub")
                 .location("Bucheon")
-                .category("test category")
+                .categoryId(1L)
                 .createdAt(LocalDateTime.now())
                 .build();
         clubMapper.insertClub(club);

--- a/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
+++ b/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
@@ -38,7 +38,7 @@ class ClubDtoValidationTest {
     @DisplayName("club dto validation - 잘못된 입력")
     void ClubDto_wrong_input() throws Exception {
         clubDto.setTitle("");
-        clubDto.setCategoryId(1L);
+        clubDto.setCategory("sports");
         clubDto.setLocation("Bucheon");
         clubDto.setCreatedAt(LocalDateTime.now());
 

--- a/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
+++ b/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
@@ -1,6 +1,7 @@
 package com.hcs.dto;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hcs.config.EnableMockMvc;
 import com.hcs.domain.Club;
 import com.hcs.mapper.ClubMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@EnableMockMvc
 @Transactional
 class ClubDtoValidationTest {
 
@@ -48,7 +49,7 @@ class ClubDtoValidationTest {
                 .accept(MediaType.APPLICATION_JSON))
                 //.with(csrf())) // security 설정 이후 코드 사용 예정
                 .andDo(print())
-                .andExpect(status().isOk())
+                .andExpect(status().is4xxClientError())
                 .andExpect(
                         (result) -> assertTrue(result.getResolvedException().getClass()
                                 .isAssignableFrom(MethodArgumentNotValidException.class))

--- a/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
+++ b/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
@@ -38,7 +38,7 @@ class ClubDtoValidationTest {
     @DisplayName("club dto validation - 잘못된 입력")
     void ClubDto_wrong_input() throws Exception {
         clubDto.setTitle("");
-        clubDto.setCategory("Book");
+        clubDto.setCategoryId(1L);
         clubDto.setLocation("Bucheon");
         clubDto.setCreatedAt(LocalDateTime.now());
 

--- a/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
@@ -1,0 +1,34 @@
+package com.hcs.mapper;
+
+import com.hcs.domain.Category;
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@EnableEncryptableProperties
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@MybatisTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[MyBatisConfig]")})
+public class CategoryMapperTest {
+
+    @Autowired
+    CategoryMapper categoryMapper;
+
+    @DisplayName("모든 카테고리 가져오기")
+    @Test
+    void selectAllCategory() {
+        int currentCategorySize = 10;
+        List<Category> categoryList = categoryMapper.selectAllCategory();
+        assertEquals(categoryList.size(), currentCategorySize);
+        assertEquals(categoryList.get(0).getId(), 1);
+        assertEquals(categoryList.get(0).getName(), "sports");
+    }
+}

--- a/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
@@ -40,7 +40,7 @@ class ClubMapperTest {
         Club club = Club.builder()
                 .title("testClub")
                 .location("Bucheon")
-                .category("test category")
+                .categoryId(1L)
                 .createdAt(LocalDateTime.now().withNano(0)) // 밀리초 단위 절삭
                 .build();
         club.setCreatedAt(LocalDateTime.now());
@@ -56,7 +56,7 @@ class ClubMapperTest {
         assertEquals(club.getDescription(), aClub.getDescription());
         //assertEquals(club.getCreatedAt(), aClub.getCreatedAt()); // TODO : 필드에 값 할당시 나노 초 단위 절삭 구현 또는 해당기능을 하는 annotation 추가하기
 
-        assertEquals(club.getCategory(), aClub.getCategory());
+        assertEquals(club.getCategoryId(), aClub.getCategoryId());
 
         assertNull(bClub);
     }
@@ -67,7 +67,7 @@ class ClubMapperTest {
         Club club = Club.builder()
                 .title("testDeleteClub")
                 .location("Bucheon")
-                .category("test category")
+                .categoryId(1L)
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -86,7 +86,7 @@ class ClubMapperTest {
         Club club = Club.builder()
                 .title("testClub")
                 .location("Bucheon")
-                .category("test category")
+                .categoryId(1L)
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -107,7 +107,7 @@ class ClubMapperTest {
         Club club = Club.builder()
                 .title("testClub")
                 .location("Bucheon")
-                .category("test category")
+                .categoryId(1L)
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -169,7 +169,7 @@ class ClubMapperTest {
                     .createdAt(LocalDateTime.now())
                     .description("this is club for test")
                     .location("Mars")
-                    .category("test")
+                    .categoryId(1L)
                     .build();
             clubMapper.insertClub(club);
             clubList.add(club);

--- a/api/src/test/java/com/hcs/service/CategoryServiceTest.java
+++ b/api/src/test/java/com/hcs/service/CategoryServiceTest.java
@@ -5,6 +5,8 @@ import com.hcs.mapper.CategoryMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,8 +29,8 @@ class CategoryServiceTest {
     @DisplayName("카테고리 리스트가 주어지면, 그 리스트 반환하기")
     @Test
     void getAllCategory(){
-        List<Category> givenCategoryList = new ArrayList<>();
         //given
+        List<Category> givenCategoryList = new ArrayList<>();
         given(categoryMapper.selectAllCategory()).willReturn(givenCategoryList);
 
         //when
@@ -36,6 +38,30 @@ class CategoryServiceTest {
 
         //then
         assertEquals(categoryList, givenCategoryList);
+
+    }
+
+    @DisplayName("카테고리 이름이 주어지면, 그 이름에 해당하는 categoryId 반환하기")
+    @ParameterizedTest
+    @ValueSource(strings={"sports","reading","music"})
+    void getCategoryId(String categoryName) {
+        //given
+        List<Category> givenCategoryList = new ArrayList<>();
+        givenCategoryList.add(new Category(1L, "sports"));
+        givenCategoryList.add(new Category(2L, "reading"));
+        givenCategoryList.add(new Category(3L, "music"));
+        given(categoryMapper.selectAllCategory()).willReturn(givenCategoryList);
+
+        //when
+        Long categoryId = categoryService.getCategoryId(categoryName);
+
+        //then
+        String givenCategoryName="";
+        for (Category c: givenCategoryList) {
+            if(categoryId.equals(c.getId()))
+                givenCategoryName = c.getName();
+        }
+        assertEquals(categoryName,givenCategoryName);
 
     }
 }

--- a/api/src/test/java/com/hcs/service/CategoryServiceTest.java
+++ b/api/src/test/java/com/hcs/service/CategoryServiceTest.java
@@ -1,0 +1,41 @@
+package com.hcs.service;
+
+import com.hcs.domain.Category;
+import com.hcs.mapper.CategoryMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @InjectMocks
+    CategoryService categoryService;
+
+    @Mock
+    CategoryMapper categoryMapper;
+
+    @DisplayName("카테고리 리스트가 주어지면, 그 리스트 반환하기")
+    @Test
+    void getAllCategory(){
+        List<Category> givenCategoryList = new ArrayList<>();
+        //given
+        given(categoryMapper.selectAllCategory()).willReturn(givenCategoryList);
+
+        //when
+        List<Category> categoryList = categoryService.getAllCategory();
+
+        //then
+        assertEquals(categoryList, givenCategoryList);
+
+    }
+}

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -44,7 +44,7 @@ class ClubServiceTest {
                 "club description",
                 LocalDateTime.now(),
                 "test location",
-                "test category");
+                1L);
 
         given(modelMapper.map(correctClubDto, Club.class)).willReturn(fixtureClub);
 

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -44,7 +44,7 @@ class ClubServiceTest {
                 "club description",
                 LocalDateTime.now(),
                 "test location",
-                1L);
+                "sports");
 
         given(modelMapper.map(correctClubDto, Club.class)).willReturn(fixtureClub);
 


### PR DESCRIPTION
**club domain 의 category 필드를 categoryId로 교체**

category 이름에 대해 국제화가 이뤄질경우를 대비해 domain이 id 값을 가지게 변경하였습니다.

- ClubDto.category -> Club.categoryId mapping 을위한 코드추가
- Club domain 의 category 필드를 categoryId로 교체
- 교체에 따른 테스트, mapper 수정
- Club table column 수정

db의 table column 도 수정되었습니다. 아래 query로 수정부탁드립니다
```
ALTER TABLE club CHANGE COLUMN category categoryId int NOT NULL;
```