### PR TITLE
TradePostService - 바뀐 경로로 import path 수정

### DIFF
--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -1,7 +1,8 @@
 package com.hcs.service;
 
 import com.hcs.domain.TradePost;
-import com.hcs.dto.TradePostDto;
+
+import com.hcs.dto.request.TradePostDto;
 import com.hcs.mapper.TradePostMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
TradePostService 에서 사용하는 TradePostDto 가 리팩토링 전 경로로 되어있어 현재 경로에 맞게 수정하였습니다. 