### PR TITLE
findBy__():tradePostMapperTest

### DIFF
--- a/api/src/main/java/com/hcs/mapper/TradePostMapper.java
+++ b/api/src/main/java/com/hcs/mapper/TradePostMapper.java
@@ -6,11 +6,13 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface TradePostMapper {
 
+    TradePost findById(long tradePostId);
+
     TradePost findByTitle(String title);
 
     void insert(TradePost tradePost);
 
-    void delete(String title);
+    void deleteById(long Id);
 
     // TODO 글쓴이의 이름 가져오기
 }

--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -1,7 +1,6 @@
 package com.hcs.service;
 
 import com.hcs.domain.TradePost;
-
 import com.hcs.dto.request.TradePostDto;
 import com.hcs.mapper.TradePostMapper;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +19,10 @@ public class TradePostService {
 
     public TradePost findByTitle(String title) {
         return tradePostMapper.findByTitle(title);
+    }
+
+    public TradePost findById(long Id) {
+        return tradePostMapper.findById(Id);
     }
 
 }

--- a/api/src/main/resources/mybatis-mapper/TradePostMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/TradePostMapperXml.xml
@@ -11,6 +11,12 @@
         where title = #{title}
     </select>
 
+    <select id="findById" parameterType="long" resultType="com.hcs.domain.TradePost">
+        select *
+        from TradePost
+        where id = #{Id}
+    </select>
+
     <insert id="insert" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.TradePost">
         insert into TradePost (authorId, title, productStatus, category, description,
                                pictures, locationName, lat, lng, price, salesStatus, registerationTime)

--- a/api/src/main/resources/sql/tradePostCreate.sql
+++ b/api/src/main/resources/sql/tradePostCreate.sql
@@ -8,10 +8,11 @@ create table TradePost
     description       VARCHAR(250) NOT NULL,
     pictures          blob,
     locationName      VARCHAR(100),
-    lat               DECIMAL(10, 8),
-    lng               DECIMAL(11, 8),
+    lng               DECIMAL(17, 14),
+    lat               DECIMAL(16, 14),
     price             int          NOT NULL,
-    salesStatus       boolean      NOT NULL,
+    views             int          NOT NULL DEFAULT 0,
+    salesStatus       boolean      NOT NULL DEFAULT 0,
     registerationTime datetime     NOT NULL,
 
     FOREIGN KEY (authorId) REFERENCES User (id) ON DELETE CASCADE

--- a/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
@@ -1,0 +1,89 @@
+package com.hcs.mapper;
+
+import com.hcs.domain.TradePost;
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableEncryptableProperties
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@MybatisTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[MyBatisConfig]")})
+class TradePostMapperTest {
+
+    @Autowired
+    TradePostMapper tradePostMapper;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    void insertTestTradePost(long authorId, String title, String productStatus, String category, String description, int price, LocalDateTime registerationTime) {
+
+        String insertSql = "insert into TradePost (authorId, title, productStatus, category, description, price, registerationTime)\n" +
+                "values (?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.update(insertSql, new Object[]{authorId, title, productStatus, category, description, price, registerationTime});
+    }
+
+
+    @DisplayName("TradePostMapper - Title로 TradePost 찾기")
+    @Test
+    void findByTitleTest() {
+
+        long authorId = 43;
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        insertTestTradePost(authorId, title, productStatus, category, description, price, registrationTime);
+
+        Optional<TradePost> returnedBy = Optional.ofNullable(tradePostMapper.findByTitle(title));
+
+        assertThat(returnedBy).isNotEmpty();
+        assertThat(returnedBy.get().getTitle()).isEqualTo(title);
+        assertThat(returnedBy.get().getProductStatus()).isEqualTo(productStatus);
+        assertThat(returnedBy.get().getCategory()).isEqualTo(category);
+        assertThat(returnedBy.get().getDescription()).isEqualTo(description);
+        assertThat(returnedBy.get().getPrice()).isEqualTo(price);
+    }
+
+    @DisplayName("TradePostMapper - Id로 TradePost 찾기")
+    @Test
+    void findByIdTest() {
+
+        long authorId = 43;
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        insertTestTradePost(authorId, title, productStatus, category, description, price, registrationTime);
+
+        Optional<TradePost> insertedTradePost = Optional.ofNullable(tradePostMapper.findByTitle(title));
+        Optional<TradePost> returnedBy = Optional.ofNullable(tradePostMapper.findById(insertedTradePost.get().getId()));
+
+        assertThat(returnedBy).isNotEmpty();
+        assertThat(returnedBy.get().getTitle()).isEqualTo(title);
+        assertThat(returnedBy.get().getProductStatus()).isEqualTo(productStatus);
+        assertThat(returnedBy.get().getCategory()).isEqualTo(category);
+        assertThat(returnedBy.get().getDescription()).isEqualTo(description);
+        assertThat(returnedBy.get().getPrice()).isEqualTo(price);
+    }
+
+
+}


### PR DESCRIPTION
`TradePostMapperTest`
- findById()
- findByEmail() 

`tradePostCreate.sql`
- `lng`, `lat` 데이터타입 수정 (범위 늘림)
- `views`, `salesStatue` default 값 0으로 줌