### PR TITLE
refactoring: ChatRoomController

### DIFF
--- a/api/src/main/java/com/hcs/controller/ChatRoomController.java
+++ b/api/src/main/java/com/hcs/controller/ChatRoomController.java
@@ -7,6 +7,8 @@ import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
 import com.hcs.dto.response.method.HcsSubmit;
 import com.hcs.service.ChatRoomService;
+import com.hcs.service.TradePostService;
+import com.hcs.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
@@ -19,23 +21,29 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequestMapping("/chat")
 public class ChatRoomController {
 
+    private final UserService userService;
+    private final TradePostService tradePostService;
     private final ChatRoomService chatRoomService;
     private final SimpMessagingTemplate template;
     private final HcsResponseManager hcsResponseManager;
     private final HcsSubmit submit;
 
     @PostMapping("/room/submit")
-    public HcsResponse createChatRoom(@RequestParam("userId") User buyer, @RequestParam(name = "tradePostId", required = false) TradePost saleTradePost) {
+    public HcsResponse createChatRoom(@RequestParam("userId") long userId, @RequestParam(name = "tradePostId", required = false) long saleTradePostId) {
+
+        User user = userService.findById(userId);
+        TradePost saleTradePost = tradePostService.findById(saleTradePostId);
 
         ChatRoom newRoom = ChatRoom.create();
 
         if (saleTradePost == null) {
-            chatRoomService.createChatRoom(newRoom, buyer);
+            chatRoomService.createChatRoom(newRoom, user); // 기본 DM창에서 방을 생성할 경우
+            // TODO 초대한 상대방에게 알람 날리기
         } else {
-            chatRoomService.createChatRoom(newRoom, buyer, saleTradePost.getAuthor());
+            chatRoomService.createChatRoom(newRoom, user, saleTradePost.getAuthor()); // 중고거래 게시물의 "판매자와 채팅" 버튼으로 방을 생성할 경우
         }
 
-        // 구매자에게 알람 날리기 : 구매자는 알람을 통해 자신의 기본 DM창으로 이동할 수 있음
+        // TODO 구매자에게 알람 날리기 : 구매자는 알람을 통해 자신의 기본 DM창으로 이동할 수 있음
 
         return hcsResponseManager.makeHcsResponse(submit.chatRoom(newRoom.getId()));
     }


### PR DESCRIPTION
`ChatRoomController`의  `createChatRoom()` (POST /chat/room/submit) 리팩토링

- `@RequestParam`로 받는 `userId`와 `tradePostId`를 바로 java domain object로 매핑하였음
  - `Converter`가 없어 `mapping error` 발생
  - long 타입으로 받은 후 service에서 매핑하였음