### PR TITLE
Club - List 기능 response 에 Dto 사용

### DIFF
--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -3,25 +3,17 @@ package com.hcs.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hcs.domain.Club;
+import com.hcs.dto.response.club.ClubInListDto;
+import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-/*
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
- */
 
 @Configuration
 public class AppConfig {
-
-    /* security 설정 이후 코드 사용 예정
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-    */
 
     @Bean
     public ModelMapper modelMapper() {
@@ -30,6 +22,11 @@ public class AppConfig {
                 .setDestinationNameTokenizer(NameTokenizers.UNDERSCORE)
                 .setSourceNameTokenizer(NameTokenizers.UNDERSCORE)
                 .setMatchingStrategy(MatchingStrategies.STRICT);
+
+        modelMapper.typeMap(Club.class, ClubInListDto.class).addMappings(mapping -> {
+            mapping.map(Club::getId, ClubInListDto::setClubId);
+        });
+
         return modelMapper;
     }
 

--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -1,15 +1,20 @@
 package com.hcs.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
+import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsList;
 import com.hcs.dto.response.method.HcsSubmit;
 import com.hcs.service.CategoryService;
 import com.hcs.service.ClubService;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -54,13 +60,11 @@ public class ClubController {
 
     @GetMapping("/list")
     public HcsResponse clubList(@RequestParam("page") int page, @RequestParam("category") String category) {
-        //TODO : managers, members 필드 대신 managerCount, memberCount 필드로 변경
-
         int count = 10;
         long categoryId = categoryService.getCategoryId(category);
-        List<Club> clubList = clubService.getClubListWithPagingAndCategory(page, count, categoryId);
+        List<ClubInListDto> clubInListDtos = clubService.getClubListWithPagingAndCategory(page, count, categoryId);
         long allClubCounts = clubService.getAllClubCounts();
-        return responseManager.makeHcsResponse(hcsList.club(clubList, category, page, count, allClubCounts));
+        return responseManager.makeHcsResponse(hcsList.club(clubInListDtos, category, page, count, allClubCounts));
     }
 
     //TODO : delete club

--- a/api/src/main/java/com/hcs/domain/Club.java
+++ b/api/src/main/java/com/hcs/domain/Club.java
@@ -1,8 +1,5 @@
 package com.hcs.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,7 +15,7 @@ import java.util.Set;
 /**
  * @Data : @Getter, @Setter, @ToString, @EqualsAndHashCode, @RequireArgsConstructor 를 한번에 설정함.
  * @EqualsAndHashCode(onlyExplicitlyIncluded = true) : equals(), hashCode() 에서 사용할 필드를 명시적으로 선언해 사용하기위해 설정함.
- * @EqualsAndHashCode.Include : 해당 애노테이션으로 지정한 필드만  equals(), hashCode() 에서 사용한다.*
+ * @EqualsAndHashCode.Include : 해당 애노테이션으로 지정한 필드만  equals(), hashCode() 에서 사용한다.
  */
 @Data @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)

--- a/api/src/main/java/com/hcs/domain/Club.java
+++ b/api/src/main/java/com/hcs/domain/Club.java
@@ -18,35 +18,34 @@ import java.util.Set;
 /**
  * @Data : @Getter, @Setter, @ToString, @EqualsAndHashCode, @RequireArgsConstructor 를 한번에 설정함.
  * @EqualsAndHashCode(onlyExplicitlyIncluded = true) : equals(), hashCode() 에서 사용할 필드를 명시적으로 선언해 사용하기위해 설정함.
- * @JsonPropertyOrder : json 직렬화 순서를 정해준다.
- * @EqualsAndHashCode.Include : 해당 애노테이션으로 지정한 필드만  equals(), hashCode() 에서 사용한다.
- * @JsonProperty : json 매핑시 해당 필드의 key의 이름을 지정한다.
+ * @EqualsAndHashCode.Include : 해당 애노테이션으로 지정한 필드만  equals(), hashCode() 에서 사용한다.*
  */
 @Data @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonPropertyOrder({"title","description","category","location","createdAt"})
 public class Club {
 
     @EqualsAndHashCode.Include
-    @JsonIgnore
     private Long id;
+
     private String title;
+
     private String description;
-    @JsonProperty("category")
+
     private Long categoryId;
-    @Temporal(TemporalType.TIMESTAMP)
+
     private String location;
+
+    @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime createdAt;
 
-
-    @JsonIgnore
     private Set<User> members = new HashSet<>();
-    @JsonIgnore
+
     private Set<User> managers = new HashSet<>(); // 관리자를 여러명 두어 최고, 서브 관리자로 role을 나눌 예정
 
-    // private int memberCount; 성능 개선시 사용 예정
-    // private int managerCount; 성능 개선시 사용 예정
+    private int memberCount;
+
+    private int managerCount;
 
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubDto.java
@@ -1,0 +1,15 @@
+package com.hcs.dto.response.club;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ClubDto {
+    private Long clubId;
+    private String clubUrl;
+    private String title;
+    private String description;
+    private String location;
+    private LocalDateTime createdAt;
+}

--- a/api/src/main/java/com/hcs/dto/response/club/ClubDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubDto.java
@@ -1,10 +1,12 @@
 package com.hcs.dto.response.club;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
 public class ClubDto {
     private Long clubId;
     private String clubUrl;

--- a/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
@@ -1,15 +1,17 @@
 package com.hcs.dto.response.club;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @EqualsAndHashCode(callSuper = true) : equals, hashcode 메소드사용시 슈퍼클래스 값 포함
  */
 
-@Data
+@Getter
+@Setter
 @EqualsAndHashCode(callSuper = true)
-public class ClubInListDto extends ClubDto{
+public class ClubInListDto extends ClubDto {
     private int managerCount;
     private int memberCount;
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
@@ -1,0 +1,15 @@
+package com.hcs.dto.response.club;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * @EqualsAndHashCode(callSuper = true) : equals, hashcode 메소드사용시 슈퍼클래스 값 포함
+ */
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ClubInListDto extends ClubDto{
+    private int managerCount;
+    private int memberCount;
+}

--- a/api/src/main/java/com/hcs/dto/response/method/HcsList.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsList.java
@@ -3,8 +3,8 @@ package com.hcs.dto.response.method;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.hcs.domain.Club;
 import com.hcs.domain.TradePost;
+import com.hcs.dto.response.club.ClubInListDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -14,8 +14,6 @@ import java.util.Map;
 
 @Component
 public class HcsList {
-
-    private final String domainUrl = "https://localhost:8443/";
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -48,7 +46,7 @@ public class HcsList {
         return hcs;
     }
 
-    public ObjectNode club(List<Club> clubList, String category, int page, int count, long totalCount) {
+    public ObjectNode club(List<ClubInListDto> clubInListDtos, String category, int page, int count, long totalCount) {
         ObjectNode hcs = objectMapper.createObjectNode();
         ObjectNode item = objectMapper.createObjectNode();
         item.put("page", page);
@@ -56,7 +54,7 @@ public class HcsList {
         item.put("totalCount", totalCount);
         item.put("category", category);
 
-        ArrayNode clubs = clubs(clubList);
+        ArrayNode clubs = clubs(clubInListDtos);
         item.set("clubs", clubs);
 
         hcs.put("status", 200);
@@ -65,17 +63,14 @@ public class HcsList {
         return hcs;
     }
 
-    private ArrayNode clubs(List<Club> clubList) {
+    private ArrayNode clubs(List<ClubInListDto> clubList) {
         ArrayNode clubs = objectMapper.createArrayNode();
-        for (Club c : clubList) {
+        for (ClubInListDto c : clubList) {
             ObjectNode clubNode = objectMapper.createObjectNode();
             ObjectNode club = objectMapper.valueToTree(c);
-            clubNode.put("clubId", c.getId());
-            clubNode.put("clubUrl", domainUrl + "club/" + c.getId());
             clubNode.setAll(club);
             clubNode.remove("category");
             clubNode.put("createdAt", c.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-            //TODO : member count, manager count 필드 추가
             clubs.add(clubNode);
         }
         return clubs;

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -2,14 +2,17 @@ package com.hcs.service;
 
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
+import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.mapper.ClubMapper;
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.session.SqlSession;
 import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.validation.Valid;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -20,6 +23,8 @@ public class ClubService {
     private final ClubMapper clubMapper;
     private final SqlSession sqlSession;
     private final CategoryService categoryService;
+    @Value("${domain.url}")
+    private String domainUrl = "";
 
     public Club saveNewClub(@Valid ClubDto clubDto) {
         Club club = modelMapper.map(clubDto, Club.class);
@@ -45,9 +50,16 @@ public class ClubService {
         }
     }
 
-    public List<Club> getClubListWithPagingAndCategory(int page, int count, long categoryId) {
+    public List<ClubInListDto> getClubListWithPagingAndCategory(int page, int count, long categoryId) {
         RowBounds rowBounds = new RowBounds((page - 1) * count, count);
-        return sqlSession.selectList("com.hcs.mapper.ClubMapper.findByPageAndCategory", categoryId, rowBounds);
+        List<Club> clubList = sqlSession.selectList("com.hcs.mapper.ClubMapper.findByPageAndCategory", categoryId, rowBounds);
+        List<ClubInListDto> clubInListDtos = new ArrayList<>();
+        for (Club c : clubList) {
+            ClubInListDto dto = modelMapper.map(c, ClubInListDto.class);
+            dto.setClubUrl(domainUrl +"club/"+ dto.getClubId());
+            clubInListDtos.add(dto);
+        }
+        return clubInListDtos;
     }
 
     public long getAllClubCounts() {

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -24,7 +24,7 @@ public class ClubService {
     private final SqlSession sqlSession;
     private final CategoryService categoryService;
     @Value("${domain.url}")
-    private String domainUrl = "";
+    private String domainUrl;
 
     public Club saveNewClub(@Valid ClubDto clubDto) {
         Club club = modelMapper.map(clubDto, Club.class);
@@ -56,7 +56,7 @@ public class ClubService {
         List<ClubInListDto> clubInListDtos = new ArrayList<>();
         for (Club c : clubList) {
             ClubInListDto dto = modelMapper.map(c, ClubInListDto.class);
-            dto.setClubUrl(domainUrl +"club/"+ dto.getClubId());
+            dto.setClubUrl(domainUrl + "club/" + dto.getClubId());
             clubInListDtos.add(dto);
         }
         return clubInListDtos;

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -40,3 +40,6 @@ management:
     web:
       exposure:
         include: "*"
+
+domain:
+  url: "https://localhost:8443/"

--- a/api/src/main/resources/sql/clubCreate.sql
+++ b/api/src/main/resources/sql/clubCreate.sql
@@ -5,7 +5,7 @@ create table Club
     description                VARCHAR(50),
     createdAt                  datetime NOT NULL,
     location                   VARCHAR(20) NOT NULL,
-    categoryId                 int NOT NULL
-    #managerCount               int DEFAULT 0,
-    #memberCount                int DEFAULT 0 성능 개선시 사용 예정
+    categoryId                 int NOT NULL,
+    managerCount               int DEFAULT 0,
+    memberCount                int DEFAULT 0
 )

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -44,7 +44,7 @@ class ClubControllerTest {
     private ObjectMapper objectMapper;
 
     @Value("${domain.url}")
-    private String domainUrl = "";
+    private String domainUrl;
 
     @DisplayName("Club Submit - 입력값 정상")
     @Test

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -10,6 +10,7 @@ import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,7 +43,8 @@ class ClubControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private final String domainUrl = "https://localhost:8443/";
+    @Value("${domain.url}")
+    private String domainUrl = "";
 
     @DisplayName("Club Submit - 입력값 정상")
     @Test


### PR DESCRIPTION
**GET club/List/ 기능의 response에 dto 사용으로 변경**
- ClubDto, ClubListDto 객체 및 dto전용 club 디렉토리 추가 (hcs.dto.response.club)
-  Club domain 코드에 json 관련 애노테이션 삭제
- 바뀐 response 와 코드에 맞게 ClubController test, ClubService test변경 및 test passed 확인
- Club domain , Club DB table 에 memberCount, managerCount 추가
- ClubUrl 필드에 사용하는 domainUrl 값을 application.yml 에 domain.url 에 값을 정의하도록 변경.
한 군데서 관리하도록 변경하였습니다.

mysql에서 아래 코드로 업데이트 하면 됩니다.
```
ALTER TABLE `club` ADD `managerCount` int DEFAULT 0;
ALTER TABLE `club` ADD `memberCount` int DEFAULT 0;
```
- 기타 사용하지 않는 주석 삭제



