### PR TITLE
refactoring:dto-User

### DIFF
--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -3,6 +3,8 @@ package com.hcs.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hcs.domain.User;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
@@ -30,6 +32,11 @@ public class AppConfig {
                 .setDestinationNameTokenizer(NameTokenizers.UNDERSCORE)
                 .setSourceNameTokenizer(NameTokenizers.UNDERSCORE)
                 .setMatchingStrategy(MatchingStrategies.STRICT);
+
+        modelMapper.typeMap(User.class, UserInfoDto.class).addMappings(mapping -> {
+            mapping.map(User::getId, UserInfoDto::setUserId);
+        });
+
         return modelMapper;
     }
 

--- a/api/src/main/java/com/hcs/controller/UserController.java
+++ b/api/src/main/java/com/hcs/controller/UserController.java
@@ -6,8 +6,10 @@ import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsSubmit;
+import com.hcs.dto.response.user.UserInfoDto;
 import com.hcs.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,6 +30,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class UserController {
 
+    private final ModelMapper modelMapper;
     private final UserService userService;
     private final HcsResponseManager hcsResponseManager;
     private final HcsInfo info;
@@ -51,7 +54,8 @@ public class UserController {
     public HcsResponse userInfo(@RequestParam("userId") long userId) {
 
         User user = userService.findById(userId);
+        UserInfoDto userInfoDto = modelMapper.map(user, UserInfoDto.class);
 
-        return hcsResponseManager.makeHcsResponse(info.user(user));
+        return hcsResponseManager.makeHcsResponse(info.user(userInfoDto));
     }
 }

--- a/api/src/main/java/com/hcs/domain/User.java
+++ b/api/src/main/java/com/hcs/domain/User.java
@@ -1,6 +1,5 @@
 package com.hcs.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,7 +13,6 @@ import java.util.Set;
 
 /**
  * @Data : @Getter, @Setter, @ToString, @EqualsAndHashCode, @RequireArgsConstructor 등의 기능을 제공
- * @JsonIgnore : jackson 라이브러리로 직렬화 할 경우 제외할 필드를 지정할 경우 사용됨
  */
 
 @Data
@@ -25,23 +23,16 @@ import java.util.Set;
 public class User {
 
     @EqualsAndHashCode.Include
-    @JsonIgnore
-    private Long id;
+    private long id;
     private String email;
     private String nickname;
-    @JsonIgnore
     private String password;
     private boolean emailVerified;
-    @JsonIgnore
     private String emailCheckToken;
-    @JsonIgnore
     private LocalDateTime emailCheckTokenGeneratedAt;
     private LocalDateTime joinedAt;
-
     private Integer age;
     private String position;
     private String location;
-    @JsonIgnore
     private Set<TradePost> tradePostList = new HashSet<>();
-
 }

--- a/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
@@ -3,7 +3,7 @@ package com.hcs.dto.response.method;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hcs.domain.Club;
-import com.hcs.domain.User;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -17,11 +17,10 @@ public class HcsInfo {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private ObjectNode profile(User user) {
-        ObjectNode item = objectMapper.createObjectNode();
-        ObjectNode profile = objectMapper.valueToTree(user);
+    private ObjectNode profile(UserInfoDto userInfoDto) {
 
-        item.put("userId", user.getId());
+        ObjectNode item = objectMapper.createObjectNode();
+        ObjectNode profile = objectMapper.valueToTree(userInfoDto);
 
         item.set("profile", profile);
 
@@ -44,9 +43,9 @@ public class HcsInfo {
         return item;
     }
 
-    public ObjectNode user(User user) {
+    public ObjectNode user(UserInfoDto userInfoDto) {
         ObjectNode hcs = objectMapper.createObjectNode();
-        ObjectNode item = profile(user);
+        ObjectNode item = profile(userInfoDto);
 
         hcs.put("status", 200);
         hcs.set("item", item);

--- a/api/src/main/java/com/hcs/dto/response/user/UserInfoDto.java
+++ b/api/src/main/java/com/hcs/dto/response/user/UserInfoDto.java
@@ -1,0 +1,20 @@
+package com.hcs.dto.response.user;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class UserInfoDto {
+
+    private long userId;
+    private String email;
+    private String nickname;
+
+    private boolean emailVerified;
+    private LocalDateTime joinedAt;
+
+    private int age;
+    private String position;
+    private String location;
+}

--- a/api/src/test/java/com/hcs/controller/UserControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/UserControllerTest.java
@@ -71,7 +71,6 @@ public class UserControllerTest {
         mockMvc.perform(get("/sign-up"))
                 .andDo(print())
                 .andExpect(status().isOk());
-
     }
 
     @DisplayName("회원 가입 처리 - 입력값 오류")
@@ -87,7 +86,6 @@ public class UserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
-                //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
                 .andExpect(status().is4xxClientError())
@@ -115,7 +113,6 @@ public class UserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
-                //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -129,15 +126,13 @@ public class UserControllerTest {
         HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
 
         assertThat(status).isEqualTo(200);
-        assertThat(item.get("userId")).isEqualTo(user.getId().intValue());
+        assertThat(item.get("userId")).isEqualTo((int) user.getId());
 
     }
 
     @DisplayName("사용자 정보 요청시 리턴되는 body를 확인")
     @Test
     void userInfo_with_correct_req() throws Exception {
-        // TODO (테스트를 위해) 사용자 추가
-
         User user = userMapper.findByEmail("noah0504@naver.com");
 
         MvcResult mvcResult = mockMvc.perform(get("/user/info")
@@ -147,18 +142,16 @@ public class UserControllerTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        // TODO mvcResult의 Body를 테스트
-
         String response = mvcResult.getResponse().getContentAsString();
 
         int status = JsonPath.parse(response).read("$.HCS.status");
         HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
 
         assertThat(status).isEqualTo(200);
-        assertThat(item.get("userId")).isEqualTo(user.getId().intValue());
 
         HashMap<String, Object> profile = (HashMap<String, Object>) item.get("profile");
 
+        assertThat(profile.get("userId")).isEqualTo((int) user.getId());
         assertThat(profile.get("email")).isEqualTo(user.getEmail());
         assertThat(profile.get("nickname")).isEqualTo(user.getNickname());
         assertThat(profile.get("emailVerified")).isEqualTo(user.isEmailVerified());


### PR DESCRIPTION
Dto Refactoring
- 모든 테스트 통과하였음

- `User`
    - Domain
        - 비즈니스 로직 제거

    - `Controller`
        -  Info
            -  userInfoDto로 mapping한 후 service 로 넘김

    - `ControllerTest`
        - item에서 userId를 내려줌
        - <img width="346" alt="스크린샷 2022-01-12 오전 4 02 09" src="https://user-images.githubusercontent.com/58963724/149005035-da7410de-9a3d-46de-b5be-a3ac10a96ad5.png">

    - `Dto`
        - UserInfoDto 생성

- `HcsInfo`
    - `User`
        - `UserInfoDto`을 넘겨받아 info를 리턴하는 로직으로 리팩토링

- `AppConfig`
    - `modelMapper`
        - `UserInfoDto` 매핑 설정
            - `User`::getId => `UserInfoDto`::setUserId
