### PR TITLE
Club - Info 기능에 Dto사용

### DIFF
--- a/api/src/main/java/com/hcs/annotation/EnableMockMvc.java
+++ b/api/src/main/java/com/hcs/annotation/EnableMockMvc.java
@@ -1,11 +1,15 @@
-package com.hcs.config;
+package com.hcs.annotation;
 
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @AutoConfigureMockMvc : Mock 테스트 시 필요한 의존성을 제공해줌.

--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -3,7 +3,9 @@ package com.hcs.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hcs.domain.User;
 import com.hcs.domain.Club;
+import com.hcs.dto.response.user.UserInfoDto;
 import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.club.ClubInfoDto;
 import org.modelmapper.ModelMapper;
@@ -23,8 +25,12 @@ public class AppConfig {
                 .setSourceNameTokenizer(NameTokenizers.UNDERSCORE)
                 .setMatchingStrategy(MatchingStrategies.STRICT);
 
+        modelMapper.typeMap(User.class, UserInfoDto.class).addMappings(mapping -> {
+            mapping.map(User::getId, UserInfoDto::setUserId);
+
         modelMapper.typeMap(Club.class, ClubInListDto.class).addMappings(mapping -> {
             mapping.map(Club::getId, ClubInListDto::setClubId);
+
         });
 
         modelMapper.typeMap(Club.class, ClubInfoDto.class).addMappings(mapping -> {

--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -3,11 +3,11 @@ package com.hcs.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.hcs.domain.User;
 import com.hcs.domain.Club;
-import com.hcs.dto.response.user.UserInfoDto;
+import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.club.ClubInfoDto;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
@@ -27,10 +27,10 @@ public class AppConfig {
 
         modelMapper.typeMap(User.class, UserInfoDto.class).addMappings(mapping -> {
             mapping.map(User::getId, UserInfoDto::setUserId);
+        });
 
         modelMapper.typeMap(Club.class, ClubInListDto.class).addMappings(mapping -> {
             mapping.map(Club::getId, ClubInListDto::setClubId);
-
         });
 
         modelMapper.typeMap(Club.class, ClubInfoDto.class).addMappings(mapping -> {

--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -8,6 +8,7 @@ import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.user.UserInfoDto;
+import com.hcs.dto.response.club.ClubInfoDto;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;

--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hcs.domain.Club;
 import com.hcs.dto.response.club.ClubInListDto;
-import org.modelmapper.Converter;
+import com.hcs.dto.response.club.ClubInfoDto;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
@@ -25,6 +25,10 @@ public class AppConfig {
 
         modelMapper.typeMap(Club.class, ClubInListDto.class).addMappings(mapping -> {
             mapping.map(Club::getId, ClubInListDto::setClubId);
+        });
+
+        modelMapper.typeMap(Club.class, ClubInfoDto.class).addMappings(mapping -> {
+            mapping.map(Club::getId, ClubInfoDto::setClubId);
         });
 
         return modelMapper;

--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -1,20 +1,17 @@
 package com.hcs.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
 import com.hcs.dto.response.club.ClubInListDto;
+import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsList;
 import com.hcs.dto.response.method.HcsSubmit;
 import com.hcs.service.CategoryService;
 import com.hcs.service.ClubService;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -52,9 +48,8 @@ public class ClubController {
 
     @GetMapping("/info")
     public HcsResponse clubInfo(@RequestParam("clubId") long id) {
-        Club club = clubService.getClub(id);
-        String category = categoryService.getCategoryName(club.getCategoryId());
-        return responseManager.makeHcsResponse(info.club(club, category));
+        ClubInfoDto clubInfoDto = clubService.getClubInfo(id);
+        return responseManager.makeHcsResponse(info.club(clubInfoDto));
 
     }
 
@@ -64,7 +59,7 @@ public class ClubController {
         long categoryId = categoryService.getCategoryId(category);
         List<ClubInListDto> clubInListDtos = clubService.getClubListWithPagingAndCategory(page, count, categoryId);
         long allClubCounts = clubService.getAllClubCounts();
-        return responseManager.makeHcsResponse(hcsList.club(clubInListDtos, category, page, count, allClubCounts));
+        return responseManager.makeHcsResponse(hcsList.club(clubInListDtos, page, count, allClubCounts));
     }
 
     //TODO : delete club

--- a/api/src/main/java/com/hcs/controller/UserController.java
+++ b/api/src/main/java/com/hcs/controller/UserController.java
@@ -6,8 +6,10 @@ import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsSubmit;
+import com.hcs.dto.response.user.UserInfoDto;
 import com.hcs.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,6 +30,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class UserController {
 
+    private final ModelMapper modelMapper;
     private final UserService userService;
     private final HcsResponseManager hcsResponseManager;
     private final HcsInfo info;
@@ -51,7 +54,8 @@ public class UserController {
     public HcsResponse userInfo(@RequestParam("userId") long userId) {
 
         User user = userService.findById(userId);
+        UserInfoDto userInfoDto = modelMapper.map(user, UserInfoDto.class);
 
-        return hcsResponseManager.makeHcsResponse(info.user(user));
+        return hcsResponseManager.makeHcsResponse(info.user(userInfoDto));
     }
 }

--- a/api/src/main/java/com/hcs/domain/User.java
+++ b/api/src/main/java/com/hcs/domain/User.java
@@ -1,6 +1,5 @@
 package com.hcs.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,7 +13,6 @@ import java.util.Set;
 
 /**
  * @Data : @Getter, @Setter, @ToString, @EqualsAndHashCode, @RequireArgsConstructor 등의 기능을 제공
- * @JsonIgnore : jackson 라이브러리로 직렬화 할 경우 제외할 필드를 지정할 경우 사용됨
  */
 
 @Data
@@ -25,23 +23,16 @@ import java.util.Set;
 public class User {
 
     @EqualsAndHashCode.Include
-    @JsonIgnore
-    private Long id;
+    private long id;
     private String email;
     private String nickname;
-    @JsonIgnore
     private String password;
     private boolean emailVerified;
-    @JsonIgnore
     private String emailCheckToken;
-    @JsonIgnore
     private LocalDateTime emailCheckTokenGeneratedAt;
     private LocalDateTime joinedAt;
-
     private Integer age;
     private String position;
     private String location;
-    @JsonIgnore
     private Set<TradePost> tradePostList = new HashSet<>();
-
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubDto.java
@@ -12,6 +12,7 @@ public class ClubDto {
     private String clubUrl;
     private String title;
     private String description;
+    private String category;
     private String location;
     private LocalDateTime createdAt;
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 public class ClubInListDto extends ClubDto {
+    private Long clubId;
     private int managerCount;
     private int memberCount;
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
@@ -12,7 +12,6 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 public class ClubInListDto extends ClubDto {
-    private Long clubId;
     private int managerCount;
     private int memberCount;
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubInfoDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubInfoDto.java
@@ -1,0 +1,15 @@
+package com.hcs.dto.response.club;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+public class ClubInfoDto extends ClubDto {
+    Set<ClubUserDto> managers;
+    Set<ClubUserDto> members;
+}

--- a/api/src/main/java/com/hcs/dto/response/club/ClubUserDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubUserDto.java
@@ -1,0 +1,12 @@
+package com.hcs.dto.response.club;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ClubUserDto {
+    Long userId;
+    String name;
+    String role;
+}

--- a/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
@@ -8,6 +8,9 @@ import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.club.ClubUserDto;
 import com.hcs.domain.Club;
 import com.hcs.dto.response.user.UserInfoDto;
+import com.hcs.domain.User;
+import com.hcs.dto.response.club.ClubInfoDto;
+import com.hcs.dto.response.club.ClubUserDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.club.ClubUserDto;
+import com.hcs.domain.Club;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -17,11 +19,10 @@ public class HcsInfo {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private ObjectNode profile(User user) {
-        ObjectNode item = objectMapper.createObjectNode();
-        ObjectNode profile = objectMapper.valueToTree(user);
+    private ObjectNode profile(UserInfoDto userInfoDto) {
 
-        item.put("userId", user.getId());
+        ObjectNode item = objectMapper.createObjectNode();
+        ObjectNode profile = objectMapper.valueToTree(userInfoDto);
 
         item.set("profile", profile);
 
@@ -56,9 +57,9 @@ public class HcsInfo {
         return item;
     }
 
-    public ObjectNode user(User user) {
+    public ObjectNode user(UserInfoDto userInfoDto) {
         ObjectNode hcs = objectMapper.createObjectNode();
-        ObjectNode item = profile(user);
+        ObjectNode item = profile(userInfoDto);
 
         hcs.put("status", 200);
         hcs.set("item", item);

--- a/api/src/main/java/com/hcs/dto/response/method/HcsList.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsList.java
@@ -46,13 +46,13 @@ public class HcsList {
         return hcs;
     }
 
-    public ObjectNode club(List<ClubInListDto> clubInListDtos, String category, int page, int count, long totalCount) {
+    public ObjectNode club(List<ClubInListDto> clubInListDtos, int page, int count, long totalCount) {
         ObjectNode hcs = objectMapper.createObjectNode();
         ObjectNode item = objectMapper.createObjectNode();
         item.put("page", page);
         item.put("count", count);
         item.put("totalCount", totalCount);
-        item.put("category", category);
+        item.put("category", clubInListDtos.get(0).getCategory());
 
         ArrayNode clubs = clubs(clubInListDtos);
         item.set("clubs", clubs);
@@ -69,7 +69,7 @@ public class HcsList {
             ObjectNode clubNode = objectMapper.createObjectNode();
             ObjectNode club = objectMapper.valueToTree(c);
             clubNode.setAll(club);
-            clubNode.remove("category");
+            clubNode.remove("category"); //상위 json 에서 사용
             clubNode.put("createdAt", c.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
             clubs.add(clubNode);
         }

--- a/api/src/main/java/com/hcs/dto/response/user/UserInfoDto.java
+++ b/api/src/main/java/com/hcs/dto/response/user/UserInfoDto.java
@@ -1,0 +1,20 @@
+package com.hcs.dto.response.user;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class UserInfoDto {
+
+    private long userId;
+    private String email;
+    private String nickname;
+
+    private boolean emailVerified;
+    private LocalDateTime joinedAt;
+
+    private int age;
+    private String position;
+    private String location;
+}

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -3,6 +3,7 @@ package com.hcs.service;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.dto.response.club.ClubInListDto;
+import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.mapper.ClubMapper;
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.RowBounds;
@@ -23,6 +24,7 @@ public class ClubService {
     private final ClubMapper clubMapper;
     private final SqlSession sqlSession;
     private final CategoryService categoryService;
+
     @Value("${domain.url}")
     private String domainUrl;
 
@@ -64,5 +66,13 @@ public class ClubService {
 
     public long getAllClubCounts() {
         return clubMapper.countByAllClubs();
+    }
+
+    public ClubInfoDto getClubInfo(long id) {
+        Club club = getClub(id);
+        ClubInfoDto dto = modelMapper.map(club, ClubInfoDto.class);
+        dto.setCategory(categoryService.getCategoryName(club.getCategoryId()));
+        dto.setClubUrl(domainUrl + "club/" + club.getId());
+        return dto;
     }
 }

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -59,6 +59,7 @@ public class ClubService {
         for (Club c : clubList) {
             ClubInListDto dto = modelMapper.map(c, ClubInListDto.class);
             dto.setClubUrl(domainUrl + "club/" + dto.getClubId());
+            dto.setCategory(categoryService.getCategoryName(c.getCategoryId()));
             clubInListDtos.add(dto);
         }
         return clubInListDtos;

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -93,7 +93,7 @@ class ClubControllerTest {
         String responseJsonClubUrl = JsonPath.parse(mvcResult.getResponse().getContentAsString()).read("$.HCS.item.club.clubUrl");
         assertEquals(requestUrl, responseJsonClubUrl);
 
-        //TODO : managers , members 객체 추가 후 테스트 수정
+        //TODO : managers , members 기능 추가 후 테스트 수정
 
     }
 

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -1,7 +1,7 @@
 package com.hcs.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hcs.config.EnableMockMvc;
+import com.hcs.annotation.EnableMockMvc;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.mapper.ClubMapper;
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ClubControllerTest {
 
     private static ClubDto clubDto = new ClubDto();
-
+    private final String domainUrl = "https://localhost:8443/";
     @Autowired
     private MockMvc mockMvc;
     @Autowired

--- a/api/src/test/java/com/hcs/controller/CommentControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/CommentControllerTest.java
@@ -1,7 +1,7 @@
 package com.hcs.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hcs.config.EnableMockMvc;
+import com.hcs.annotation.EnableMockMvc;
 import com.hcs.dto.request.CommentDto;
 import com.jayway.jsonpath.JsonPath;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;

--- a/api/src/test/java/com/hcs/controller/ExceptionAdvisorTest.java
+++ b/api/src/test/java/com/hcs/controller/ExceptionAdvisorTest.java
@@ -1,6 +1,6 @@
 package com.hcs.controller;
 
-import com.hcs.config.EnableMockMvc;
+import com.hcs.annotation.EnableMockMvc;
 import com.hcs.exception.ErrorCode;
 import com.jayway.jsonpath.JsonPath;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;

--- a/api/src/test/java/com/hcs/controller/UserControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/UserControllerTest.java
@@ -31,7 +31,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 /**
  * @SpringBootTest : 통합테스트를 목적으로 SpringBoot에서 제공하는 테스트 어노테이션
  * @EnableMockMvc : MockMvc 한글 깨짐 현상을 해결하기 위해 @AutoConfigureMockMvc에 주입시킬 필터가 추가된 어노테이션.

--- a/api/src/test/java/com/hcs/controller/UserControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/UserControllerTest.java
@@ -1,7 +1,7 @@
 package com.hcs.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hcs.config.EnableMockMvc;
+import com.hcs.annotation.EnableMockMvc;
 import com.hcs.domain.User;
 import com.hcs.dto.request.SignUpDto;
 import com.hcs.mapper.UserMapper;

--- a/api/src/test/java/com/hcs/controller/UserControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/UserControllerTest.java
@@ -70,7 +70,6 @@ public class UserControllerTest {
         mockMvc.perform(get("/sign-up"))
                 .andDo(print())
                 .andExpect(status().isOk());
-
     }
 
     @DisplayName("회원 가입 처리 - 입력값 오류")
@@ -86,7 +85,6 @@ public class UserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
-                //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
                 .andExpect(status().is4xxClientError())
@@ -114,7 +112,6 @@ public class UserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
-                //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -128,15 +125,13 @@ public class UserControllerTest {
         HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
 
         assertThat(status).isEqualTo(200);
-        assertThat(item.get("userId")).isEqualTo(user.getId().intValue());
+        assertThat(item.get("userId")).isEqualTo((int) user.getId());
 
     }
 
     @DisplayName("사용자 정보 요청시 리턴되는 body를 확인")
     @Test
     void userInfo_with_correct_req() throws Exception {
-        // TODO (테스트를 위해) 사용자 추가
-
         User user = userMapper.findByEmail("noah0504@naver.com");
 
         MvcResult mvcResult = mockMvc.perform(get("/user/info")
@@ -146,18 +141,16 @@ public class UserControllerTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        // TODO mvcResult의 Body를 테스트
-
         String response = mvcResult.getResponse().getContentAsString();
 
         int status = JsonPath.parse(response).read("$.HCS.status");
         HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
 
         assertThat(status).isEqualTo(200);
-        assertThat(item.get("userId")).isEqualTo(user.getId().intValue());
 
         HashMap<String, Object> profile = (HashMap<String, Object>) item.get("profile");
 
+        assertThat(profile.get("userId")).isEqualTo((int) user.getId());
         assertThat(profile.get("email")).isEqualTo(user.getEmail());
         assertThat(profile.get("nickname")).isEqualTo(user.getNickname());
         assertThat(profile.get("emailVerified")).isEqualTo(user.isEmailVerified());

--- a/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
+++ b/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
@@ -1,14 +1,13 @@
 package com.hcs.dto;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hcs.config.EnableMockMvc;
+import com.hcs.annotation.EnableMockMvc;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.mapper.ClubMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -45,9 +44,9 @@ class ClubDtoValidationTest {
         clubDto.setCreatedAt(LocalDateTime.now());
 
         mockMvc.perform(post("/club/submit")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(clubDto))
-                .accept(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clubDto))
+                        .accept(MediaType.APPLICATION_JSON))
                 //.with(csrf())) // security 설정 이후 코드 사용 예정
                 .andDo(print())
                 .andExpect(status().is4xxClientError())

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -3,6 +3,7 @@ package com.hcs.service;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.dto.response.club.ClubInListDto;
+import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.mapper.ClubMapper;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.session.SqlSession;
@@ -49,10 +50,17 @@ class ClubServiceTest {
 
     @BeforeAll
     static void init() { //TODO : 추후 test 용 fixer 만들기
-        fixtureClub = Club.builder().id(1L).title("test club").build();
+        fixtureClub = Club.builder()
+                .id(1L)
+                .title("test club")
+                .categoryId(1L)
+                .createdAt(LocalDateTime.now())
+                .description("description")
+                .location("test location")
+                .build();
     }
 
-    @DisplayName("club dto를 db에 저장한다.")
+    @DisplayName("club dto를 db에 저장하기")
     @Test
     void saveNewClub() {
         //given
@@ -74,7 +82,7 @@ class ClubServiceTest {
 
     }
 
-    @DisplayName("club id로 club 데이터를 가져온다.")
+    @DisplayName("club id로 club 데이터를 가져오기")
     @Test
     void getClub() {
         //given
@@ -133,5 +141,26 @@ class ClubServiceTest {
 
         //then
         assertEquals(totalClubCount, givenTotalClubCount);
+    }
+
+    @DisplayName("id 값이 주어지면 클럽 정보 반환하기")
+    @Test
+    void getClubInfo() {
+        //given
+        long givenClubId = fixtureClub.getId();
+        ClubInfoDto givenDto = new ClubInfoDto();
+        given(clubMapper.findById(fixtureClub.getId())).willReturn(fixtureClub);
+        given(modelMapper.map(fixtureClub, ClubInfoDto.class)).willReturn(givenDto);
+        given(categoryService.getCategoryName(anyLong())).willReturn(eq("sports"));
+        String domainUrl = "https://localhost:8443/";
+        ReflectionTestUtils.setField(clubService, "domainUrl", domainUrl); //private field 에 값 주입
+
+        //when
+        ClubInfoDto clubInfoDto = clubService.getClubInfo(givenClubId);
+
+        //then
+        assertEquals(clubInfoDto, givenDto);
+        assertEquals(clubInfoDto.getClubUrl(), domainUrl + "club/" + fixtureClub.getId());
+
     }
 }

--- a/api/src/test/java/com/hcs/validator/UserValidationTest.java
+++ b/api/src/test/java/com/hcs/validator/UserValidationTest.java
@@ -1,7 +1,7 @@
 package com.hcs.validator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hcs.config.EnableMockMvc;
+import com.hcs.annotation.EnableMockMvc;
 import com.hcs.controller.test.TestUserController;
 import com.hcs.controller.test.TestUserControllerWithoutValid;
 import com.hcs.dto.request.SignUpDto;
@@ -54,7 +54,7 @@ public class UserValidationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
-                        //.with(csrf())) // security 설정 이후 코드 사용 예정
+                //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
                 .andExpect(handler().handlerType(TestUserController.class))
@@ -74,7 +74,7 @@ public class UserValidationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
-                        //.with(csrf())) // security 설정 이후 코드 사용 예정
+                //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
                 .andExpect(handler().handlerType(TestUserControllerWithoutValid.class))


### PR DESCRIPTION
- `AppConfig` : dto를 위한 맵핑 추가
- `ClubController' : responseManager로 ClubInfoDto전달, 파라미터 리팩토링
- `ClubInfoDto` , `ClubUserDto (manager, member 용도)`  객체 선언
- `HcsInfo' : ClubListDto를 사용해 json 생성하도록 변경
- `HcsLisg' : category 파라미터를 clubDto안으로 넣어 리팩토링
- `ClubService` : ClubInfoDto를 반환하는 테스트
