### PR TITLE
refactoring

### DIFF
--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -3,11 +3,10 @@ package com.hcs.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.hcs.domain.User;
 import com.hcs.domain.Club;
-import com.hcs.dto.response.user.UserInfoDto;
+import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInListDto;
-import org.modelmapper.Converter;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
@@ -27,10 +26,10 @@ public class AppConfig {
 
         modelMapper.typeMap(User.class, UserInfoDto.class).addMappings(mapping -> {
             mapping.map(User::getId, UserInfoDto::setUserId);
+        });
 
         modelMapper.typeMap(Club.class, ClubInListDto.class).addMappings(mapping -> {
             mapping.map(Club::getId, ClubInListDto::setClubId);
-
         });
 
         return modelMapper;


### PR DESCRIPTION
`AppConfig` 쪽의 `modelMapper` 설정 중`typeMap()`의 중괄호가 쌍에 맞지않게 닫힌 채 merge되어 이를 바로잡은 리팩토링입니다.

- 또한 `org.modelmapper.Converter` 는 사용되지 않아 지웠습니다.