### PR TITLE
Club - Info 기능에 Dto사용

### DIFF
--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -7,6 +7,7 @@ import com.hcs.domain.Club;
 import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.user.UserInfoDto;
+import com.hcs.dto.response.club.ClubInfoDto;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
@@ -30,6 +31,10 @@ public class AppConfig {
 
         modelMapper.typeMap(Club.class, ClubInListDto.class).addMappings(mapping -> {
             mapping.map(Club::getId, ClubInListDto::setClubId);
+        });
+
+        modelMapper.typeMap(Club.class, ClubInfoDto.class).addMappings(mapping -> {
+            mapping.map(Club::getId, ClubInfoDto::setClubId);
         });
 
         return modelMapper;

--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -1,20 +1,17 @@
 package com.hcs.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
 import com.hcs.dto.response.club.ClubInListDto;
+import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsList;
 import com.hcs.dto.response.method.HcsSubmit;
 import com.hcs.service.CategoryService;
 import com.hcs.service.ClubService;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -52,9 +48,8 @@ public class ClubController {
 
     @GetMapping("/info")
     public HcsResponse clubInfo(@RequestParam("clubId") long id) {
-        Club club = clubService.getClub(id);
-        String category = categoryService.getCategoryName(club.getCategoryId());
-        return responseManager.makeHcsResponse(info.club(club, category));
+        ClubInfoDto clubInfoDto = clubService.getClubInfo(id);
+        return responseManager.makeHcsResponse(info.club(clubInfoDto));
 
     }
 
@@ -64,7 +59,7 @@ public class ClubController {
         long categoryId = categoryService.getCategoryId(category);
         List<ClubInListDto> clubInListDtos = clubService.getClubListWithPagingAndCategory(page, count, categoryId);
         long allClubCounts = clubService.getAllClubCounts();
-        return responseManager.makeHcsResponse(hcsList.club(clubInListDtos, category, page, count, allClubCounts));
+        return responseManager.makeHcsResponse(hcsList.club(clubInListDtos, page, count, allClubCounts));
     }
 
     //TODO : delete club

--- a/api/src/main/java/com/hcs/dto/response/club/ClubDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubDto.java
@@ -12,6 +12,7 @@ public class ClubDto {
     private String clubUrl;
     private String title;
     private String description;
+    private String category;
     private String location;
     private LocalDateTime createdAt;
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 public class ClubInListDto extends ClubDto {
+    private Long clubId;
     private int managerCount;
     private int memberCount;
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubInListDto.java
@@ -12,7 +12,6 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 public class ClubInListDto extends ClubDto {
-    private Long clubId;
     private int managerCount;
     private int memberCount;
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubInfoDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubInfoDto.java
@@ -1,0 +1,15 @@
+package com.hcs.dto.response.club;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+public class ClubInfoDto extends ClubDto {
+    Set<ClubUserDto> managers;
+    Set<ClubUserDto> members;
+}

--- a/api/src/main/java/com/hcs/dto/response/club/ClubUserDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubUserDto.java
@@ -1,0 +1,12 @@
+package com.hcs.dto.response.club;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ClubUserDto {
+    Long userId;
+    String name;
+    String role;
+}

--- a/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
@@ -1,9 +1,13 @@
 package com.hcs.dto.response.method;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hcs.domain.Club;
 import com.hcs.dto.response.user.UserInfoDto;
+import com.hcs.domain.User;
+import com.hcs.dto.response.club.ClubInfoDto;
+import com.hcs.dto.response.club.ClubUserDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -11,8 +15,6 @@ import java.time.format.DateTimeFormatter;
 
 @Component
 public class HcsInfo {
-
-    private final String domainUrl = "https://localhost:8443/";
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -27,18 +29,30 @@ public class HcsInfo {
         return item;
     }
 
-    private ObjectNode clubInfo(Club club, String category) {
+    private ObjectNode clubInfo(ClubInfoDto clubInfoDto) {
         ObjectNode item = objectMapper.createObjectNode();
         ObjectNode clubNode = objectMapper.createObjectNode();
-        clubNode.put("clubUrl", domainUrl + "club/" + club.getId());
-        ObjectNode clubObject = objectMapper.valueToTree(club).require();
+
+        ObjectNode clubObject = objectMapper.valueToTree(clubInfoDto);
         clubNode.setAll(clubObject);
-        clubNode.put("category", category);
-        clubNode.put("createdAt", club.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        clubNode.remove("clubId"); //상위 json 에서 사용
+        clubNode.put("createdAt", clubInfoDto.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
 
-        //TODO : managers ,members 객체 추가
+        ArrayNode arrayNode = objectMapper.createArrayNode();
+        for (ClubUserDto dto : clubInfoDto.getManagers()) {
+            ObjectNode node = objectMapper.valueToTree(dto);
+            arrayNode.add(node);
+        }
+        clubNode.set("managers", arrayNode);
 
-        item.put("clubId", club.getId());
+        arrayNode = objectMapper.createArrayNode();
+        for (ClubUserDto dto : clubInfoDto.getMembers()) {
+            ObjectNode node = objectMapper.valueToTree(dto);
+            arrayNode.add(node);
+        }
+        clubNode.set("members", arrayNode);
+
+        item.put("clubId", clubInfoDto.getClubId());
         item.set("club", clubNode);
         return item;
     }
@@ -53,9 +67,9 @@ public class HcsInfo {
         return hcs;
     }
 
-    public ObjectNode club(Club club, String category) {
+    public ObjectNode club(ClubInfoDto clubInfoDto) {
         ObjectNode hcs = objectMapper.createObjectNode();
-        ObjectNode item = clubInfo(club, category);
+        ObjectNode item = clubInfo(clubInfoDto);
 
         hcs.put("status", 200);
         hcs.set("item", item);

--- a/api/src/main/java/com/hcs/dto/response/method/HcsList.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsList.java
@@ -46,13 +46,13 @@ public class HcsList {
         return hcs;
     }
 
-    public ObjectNode club(List<ClubInListDto> clubInListDtos, String category, int page, int count, long totalCount) {
+    public ObjectNode club(List<ClubInListDto> clubInListDtos, int page, int count, long totalCount) {
         ObjectNode hcs = objectMapper.createObjectNode();
         ObjectNode item = objectMapper.createObjectNode();
         item.put("page", page);
         item.put("count", count);
         item.put("totalCount", totalCount);
-        item.put("category", category);
+        item.put("category", clubInListDtos.get(0).getCategory());
 
         ArrayNode clubs = clubs(clubInListDtos);
         item.set("clubs", clubs);
@@ -69,7 +69,7 @@ public class HcsList {
             ObjectNode clubNode = objectMapper.createObjectNode();
             ObjectNode club = objectMapper.valueToTree(c);
             clubNode.setAll(club);
-            clubNode.remove("category");
+            clubNode.remove("category"); //상위 json 에서 사용
             clubNode.put("createdAt", c.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
             clubs.add(clubNode);
         }

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -3,6 +3,7 @@ package com.hcs.service;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.dto.response.club.ClubInListDto;
+import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.mapper.ClubMapper;
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.RowBounds;
@@ -23,6 +24,7 @@ public class ClubService {
     private final ClubMapper clubMapper;
     private final SqlSession sqlSession;
     private final CategoryService categoryService;
+
     @Value("${domain.url}")
     private String domainUrl;
 
@@ -64,5 +66,13 @@ public class ClubService {
 
     public long getAllClubCounts() {
         return clubMapper.countByAllClubs();
+    }
+
+    public ClubInfoDto getClubInfo(long id) {
+        Club club = getClub(id);
+        ClubInfoDto dto = modelMapper.map(club, ClubInfoDto.class);
+        dto.setCategory(categoryService.getCategoryName(club.getCategoryId()));
+        dto.setClubUrl(domainUrl + "club/" + club.getId());
+        return dto;
     }
 }

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -59,6 +59,7 @@ public class ClubService {
         for (Club c : clubList) {
             ClubInListDto dto = modelMapper.map(c, ClubInListDto.class);
             dto.setClubUrl(domainUrl + "club/" + dto.getClubId());
+            dto.setCategory(categoryService.getCategoryName(c.getCategoryId()));
             clubInListDtos.add(dto);
         }
         return clubInListDtos;

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ClubControllerTest {
 
     private static ClubDto clubDto = new ClubDto();
-    private final String domainUrl = "https://localhost:8443/";
+
     @Autowired
     private MockMvc mockMvc;
     @Autowired

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -93,7 +93,7 @@ class ClubControllerTest {
         String responseJsonClubUrl = JsonPath.parse(mvcResult.getResponse().getContentAsString()).read("$.HCS.item.club.clubUrl");
         assertEquals(requestUrl, responseJsonClubUrl);
 
-        //TODO : managers , members 객체 추가 후 테스트 수정
+        //TODO : managers , members 기능 추가 후 테스트 수정
 
     }
 

--- a/api/src/test/java/com/hcs/controller/UserControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/UserControllerTest.java
@@ -31,7 +31,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 /**
  * @SpringBootTest : 통합테스트를 목적으로 SpringBoot에서 제공하는 테스트 어노테이션
  * @EnableMockMvc : MockMvc 한글 깨짐 현상을 해결하기 위해 @AutoConfigureMockMvc에 주입시킬 필터가 추가된 어노테이션.

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -108,7 +108,7 @@ class ClubServiceTest {
         List<Club> givnClubList = new ArrayList<>();
         ClubInListDto dto;
         for (int i = 0; i < count; i++) {
-            givnClubList.add(new Club());
+            givnClubList.add(fixtureClub);
             dto = new ClubInListDto();
             dto.setClubId(1L);
             givenClubInListDtos.add(dto);
@@ -116,10 +116,10 @@ class ClubServiceTest {
         doReturn(givnClubList).when(sqlSession).selectList(eq("com.hcs.mapper.ClubMapper.findByPageAndCategory"), anyLong(), any(RowBounds.class));
         ClubInListDto clubInListDto = new ClubInListDto();
         clubInListDto.setClubId(1L);
-        Club c = new Club();
-        given(modelMapper.map(c, ClubInListDto.class)).willReturn(clubInListDto);
+        given(modelMapper.map(fixtureClub, ClubInListDto.class)).willReturn(clubInListDto);
         String domainUrl = "https://localhost:8443/";
         ReflectionTestUtils.setField(clubService, "domainUrl", domainUrl); //private field 에 값 주입
+        given(categoryService.getCategoryName(anyLong())).willReturn("sports");
 
         //when
         List<ClubInListDto> clubInListDtos = clubService.getClubListWithPagingAndCategory(page, count, categoryId);

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -3,6 +3,7 @@ package com.hcs.service;
 import com.hcs.domain.Club;
 import com.hcs.dto.request.ClubDto;
 import com.hcs.dto.response.club.ClubInListDto;
+import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.mapper.ClubMapper;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.session.SqlSession;
@@ -49,10 +50,17 @@ class ClubServiceTest {
 
     @BeforeAll
     static void init() { //TODO : 추후 test 용 fixer 만들기
-        fixtureClub = Club.builder().id(1L).title("test club").build();
+        fixtureClub = Club.builder()
+                .id(1L)
+                .title("test club")
+                .categoryId(1L)
+                .createdAt(LocalDateTime.now())
+                .description("description")
+                .location("test location")
+                .build();
     }
 
-    @DisplayName("club dto를 db에 저장한다.")
+    @DisplayName("club dto를 db에 저장하기")
     @Test
     void saveNewClub() {
         //given
@@ -74,7 +82,7 @@ class ClubServiceTest {
 
     }
 
-    @DisplayName("club id로 club 데이터를 가져온다.")
+    @DisplayName("club id로 club 데이터를 가져오기")
     @Test
     void getClub() {
         //given
@@ -133,5 +141,26 @@ class ClubServiceTest {
 
         //then
         assertEquals(totalClubCount, givenTotalClubCount);
+    }
+
+    @DisplayName("id 값이 주어지면 클럽 정보 반환하기")
+    @Test
+    void getClubInfo() {
+        //given
+        long givenClubId = fixtureClub.getId();
+        ClubInfoDto givenDto = new ClubInfoDto();
+        given(clubMapper.findById(fixtureClub.getId())).willReturn(fixtureClub);
+        given(modelMapper.map(fixtureClub, ClubInfoDto.class)).willReturn(givenDto);
+        given(categoryService.getCategoryName(anyLong())).willReturn(eq("sports"));
+        String domainUrl = "https://localhost:8443/";
+        ReflectionTestUtils.setField(clubService, "domainUrl", domainUrl); //private field 에 값 주입
+
+        //when
+        ClubInfoDto clubInfoDto = clubService.getClubInfo(givenClubId);
+
+        //then
+        assertEquals(clubInfoDto, givenDto);
+        assertEquals(clubInfoDto.getClubUrl(), domainUrl + "club/" + fixtureClub.getId());
+
     }
 }


### PR DESCRIPTION
- `AppConfig` : dto를 위한 맵핑 추가
- `ClubController` : responseManager로 ClubInfoDto전달, 파라미터 리팩토링
- `ClubInfoDto` , `ClubUserDto (manager, member 용도)`  객체 선언
- `HcsInfo` : ClubListDto를 사용해 json 생성하도록 변경
- `HcsLisg` : category 파라미터를 clubDto안으로 넣어 리팩토링
- `ClubService` : ClubInfoDto를 반환하는 테스트

#115 와 같은 내용의 pr 입니다.  main 과 겹치는 부분이 있어 다시 pr 을 올렸습니다.
