### PR TITLE
refactoring:handleBindException

### DIFF
--- a/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
+++ b/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
@@ -38,15 +38,16 @@ public class ExceptionAdvisor {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ValidationResult handleBindException(BindException bindException, Locale locale) {
-        return ValidationResult.create(bindException, messageSource, locale);
+    public HcsResponse handleBindException(BindException bindException, Locale locale) {
+        ErrorCode error = ErrorCode.METHOD_ARGUMENT_NOT_VALID;
+        ValidationResult errorResults = ValidationResult.create(bindException, messageSource, locale);
+        return hcsResponseManager.makeHcsResponse(hcsException.validation(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage()), errorResults));
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(NumberFormatException.class)
     public HcsResponse NumberFormatExceptionHandler() {
         ErrorCode error = ErrorCode.NUMBER_FORMAT;
-//        return hcsResponseManager.Exception(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage()));
         return hcsResponseManager.makeHcsResponse(hcsException.exception(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage())));
     }
 

--- a/api/src/main/java/com/hcs/dto/response/method/HcsException.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsException.java
@@ -1,8 +1,11 @@
 package com.hcs.dto.response.method;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hcs.exception.result.ExceptionResult;
+import com.hcs.exception.result.FieldErrorDetail;
+import com.hcs.exception.result.ValidationResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +22,22 @@ public class HcsException {
 
         hcs.put("status", status);
         hcs.set("item", item);
+
+        return hcs;
+    }
+
+    public ObjectNode validation(int status, ExceptionResult exceptionResult, ValidationResult errors) {
+        ObjectNode hcs = this.exception(status, exceptionResult);
+
+        ArrayNode errorLists = objectMapper.createArrayNode();
+
+        for (FieldErrorDetail error : errors.getErrors()) {
+            ObjectNode errorNode = objectMapper.valueToTree(error);
+            errorLists.add(errorNode);
+        }
+
+        ObjectNode item = (ObjectNode) hcs.get("item");
+        item.set("errors", errorLists);
 
         return hcs;
     }

--- a/api/src/main/java/com/hcs/exception/ErrorCode.java
+++ b/api/src/main/java/com/hcs/exception/ErrorCode.java
@@ -6,10 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
+    METHOD_ARGUMENT_NOT_VALID(400, -1, "request body로 전송된 데이터가 검증단계를 통과하지 못함"),
     NUMBER_FORMAT(400, -2, "숫자형으로 요청해주세요");
 
     private int status;
     private int errorCode;
     private String message;
-
 }

--- a/api/src/main/java/com/hcs/exception/HcsExceptionType.java
+++ b/api/src/main/java/com/hcs/exception/HcsExceptionType.java
@@ -1,4 +1,0 @@
-package com.hcs.exception;
-
-public interface HcsExceptionType {
-}

--- a/api/src/main/java/com/hcs/exception/result/FieldErrorDetail.java
+++ b/api/src/main/java/com/hcs/exception/result/FieldErrorDetail.java
@@ -12,14 +12,12 @@ import java.util.Locale;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class FieldErrorDetail {
 
-    private String objectName;
     private String field;
     private String code;
     private String message;
 
     public static FieldErrorDetail create(FieldError fieldError, MessageSource messageSource, Locale locale) {
         return new FieldErrorDetail(
-                fieldError.getObjectName(),
                 fieldError.getField(),
                 fieldError.getCode(),
                 messageSource.getMessage(fieldError, locale));

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -35,7 +35,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ClubControllerTest {
 
     private static ClubDto clubDto = new ClubDto();
-    private final String domainUrl = "https://localhost:8443/";
     @Autowired
     private MockMvc mockMvc;
     @Autowired

--- a/api/src/test/java/com/hcs/controller/UserControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/UserControllerTest.java
@@ -93,10 +93,10 @@ public class UserControllerTest {
 
         String response = mvcResult.getResponse().getContentAsString();
 
-        int length = JsonPath.parse(response).read("$.errors.length()");
+        int length = JsonPath.parse(response).read("$.HCS.item.errors.length()");
 
         for (int i = 0; i < length; i++) {
-            String field = JsonPath.parse(response).read("$.errors[" + i + "].field");
+            String field = JsonPath.parse(response).read("$.HCS.item.errors[" + i + "].field");
             assertThat(invalidFields).contains(field);
         }
     }

--- a/api/src/test/java/com/hcs/validator/UserValidationTest.java
+++ b/api/src/test/java/com/hcs/validator/UserValidationTest.java
@@ -54,11 +54,10 @@ public class UserValidationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
-                //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
                 .andExpect(handler().handlerType(TestUserController.class))
-                .andExpect(status().isOk());
+                .andExpect(status().is4xxClientError());
 
     }
 
@@ -74,7 +73,6 @@ public class UserValidationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(testSignUpDto))
                         .accept(MediaType.APPLICATION_JSON))
-                //.with(csrf())) // security 설정 이후 코드 사용 예정
 
                 .andDo(print())
                 .andExpect(handler().handlerType(TestUserControllerWithoutValid.class))


### PR DESCRIPTION
validation 에러에 대한 응답을 만들어진 스키마로 내려주었습니다.

<img width="726" alt="스크린샷 2022-01-13 오전 12 28 42" src="https://user-images.githubusercontent.com/58963724/149170212-dcedfad0-178c-4ed6-874a-217d7d2b39d6.png">

- `status` : 상태코드
- `item` 
  - `errorCode` : HCS 서비스에서 사용되는 에러코드. 
  - `message` : invalid 원인에 대한 메시지
  - `errors` 
    - `field` : 검증단계에서 통과되지 못한 필드
    - `code` : invalid의 원인
    - `message` : invalid의 상세 메시지