### PR TITLE
DataSourceConfig

### DIFF
--- a/api/src/main/java/com/hcs/domain/UserForJPA.java
+++ b/api/src/main/java/com/hcs/domain/UserForJPA.java
@@ -1,0 +1,26 @@
+package com.hcs.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class UserForJPA {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String email;
+    private String nickname;
+    private String password;
+}

--- a/api/src/main/java/com/hcs/mapper/UserMapper.java
+++ b/api/src/main/java/com/hcs/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.hcs.mapper;
 
 import com.hcs.domain.User;
+import com.hcs.domain.UserForJPA;
 import org.apache.ibatis.annotations.Mapper;
 
 /**
@@ -17,4 +18,6 @@ public interface UserMapper {
     long insertUser(User user);
 
     long deleteUserByEmail(String email);
+
+    UserForJPA findUserForJpaByEmail(String email);
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -20,9 +20,20 @@ spring:
       jdbc-url: "jdbc:mysql://localhost:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
       username: ENC(/vfTGzkQsvDmJGsLHCRGk8WaCVxqrAkS)
       password: ENC(/7M0dZ5y6e2xyeC2YPa3Jj7kqrJCYaCn)
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    properties:
+      hibernate:
+        format_sql: true
+        implicit_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
+        physical_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
+        hbm2ddl.auto: update
+    open-in-view: false
+    show-sql: true
   redis:
     host: localhost
     port: 6379
+
 
 mybatis:
   mapper-locations: classpath:mybatis-mapper/*.xml

--- a/api/src/main/resources/mybatis-mapper/UserMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/UserMapperXml.xml
@@ -3,8 +3,6 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.hcs.mapper.UserMapper">
-    <cache/>
-
     <select id="findById" parameterType="long" resultType="com.hcs.domain.User">
         select *
         from User
@@ -30,4 +28,9 @@
         where HCS.User.email = #{email}
     </delete>
 
+    <select id="findUserForJpaByEmail" parameterType="String" resultType="com.hcs.domain.UserForJPA">
+        select *
+        from user_forjpa
+        where email = #{email}
+    </select>
 </mapper>

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ClubControllerTest {
 
     private static ClubDto clubDto = new ClubDto();
-    private final String domainUrl = "https://localhost:8443/";
+    //    private final String domainUrl = "https://localhost:8443/";
     @Autowired
     private MockMvc mockMvc;
     @Autowired

--- a/api/src/test/java/com/hcs/setting/JpaWithMybatisTests.java
+++ b/api/src/test/java/com/hcs/setting/JpaWithMybatisTests.java
@@ -1,0 +1,72 @@
+package com.hcs.setting;
+
+import com.hcs.domain.UserForJPA;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @PersistenceContext : EntityManager를 직접 사용하는 경우 주입받을 때 사용되는 어노테이션.
+ */
+
+@SpringBootTest
+@Transactional
+public class JpaWithMybatisTests {
+
+    @PersistenceContext(unitName = "default")
+    private EntityManager em;
+
+    @Autowired
+    private SqlSession sqlSession;
+
+    @DisplayName("트랜잭션 테스트 - not commit JPA query")
+    @Test
+    public void test() {
+        String testEmail = "test@naver.com";
+
+        UserForJPA jpaUserForJPA = this.make(testEmail);
+
+        em.persist(jpaUserForJPA);
+
+        UserForJPA MybatisUserForJPA = sqlSession.selectOne("com.hcs.mapper.UserMapper.findUserForJpaByEmail", testEmail);
+
+        assertThat(MybatisUserForJPA).isNull();
+    }
+
+    @DisplayName("트랜잭션 테스트 - commit JPA query")
+    @Test
+    public void test2() {
+        String testEmail = "test@naver.com";
+
+        UserForJPA jpaUserForJPA = this.make(testEmail);
+
+        em.persist(jpaUserForJPA);
+        em.flush();
+
+        UserForJPA MybatisUserForJPA = sqlSession.selectOne("com.hcs.mapper.UserMapper.findUserForJpaByEmail", testEmail);
+
+        assertThat(MybatisUserForJPA).isNotNull();
+    }
+
+    public UserForJPA make(String testEmail) {
+        String testNickname = "test";
+        String testPassword = "password";
+
+        UserForJPA jpaUserForJPA = UserForJPA.builder()
+                .email(testEmail)
+                .nickname(testNickname)
+                .password(testPassword)
+                .build();
+
+        return jpaUserForJPA;
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-websocket'
         implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation 'org.springframework.boot:spring-boot-test-autoconfigure:2.6.0'
         implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.0'
         implementation 'org.modelmapper:modelmapper:2.4.4'


### PR DESCRIPTION
`JPA`와 `MyBatis`를 혼용하여 사용할 때 트랜잭션 매니저를 각각의 구현체가 아닌 하나의 객체에서 트랜잭션을 관리해야 함
- `Mybatis`의 `DataSource`를 `JPA`의 `EntityManagerFactory`도 접근이 가능하기 때문에 `JPA`의 트랜잭션 매니저인 `JpaTransactionManager` 에게 맡기면 혼용이 가능하다
- 단, `JpaTransactionManager` 와 `JDBC Connection`을 위한 `DataSource`는 동일한 `DataSource` 객체를 바라보고 있어야 트랜잭션이 제대로 묶일 수 있음

또한 해당 설정으로 `JPA`와 `Mybatis`를 섞어 쓰더라도 트랜잭션이 보장되는지 테스트하였음
- 객체를 영속화 한 후에 커밋 여부를 가지고 `Mybatis`에서 조회할 수 있는지 테스트하였음

Reference
[https://docs.spring.io/spring-framework/docs/3.0.x/javadoc-api/org/springframework/orm/jpa/JpaTransactionManager.html
]()