### PR TITLE
refactoring:modify from @MybatisTest to @DataJpaTest for mapperTest

### DIFF
--- a/api/src/main/java/com/hcs/config/DataSourceConfig.java
+++ b/api/src/main/java/com/hcs/config/DataSourceConfig.java
@@ -28,7 +28,7 @@ import javax.sql.DataSource;
  */
 
 @Configuration
-@EnableJpaRepositories(basePackages = "com.hcs.repository", entityManagerFactoryRef = "entityManagerFactory", transactionManagerRef = "transactionManager")
+@EnableJpaRepositories(entityManagerFactoryRef = "entityManagerFactory", transactionManagerRef = "transactionManager")
 @MapperScan(basePackages = "com.hcs.mapper", sqlSessionFactoryRef = "SqlSessionFactory")
 public class DataSourceConfig {
 

--- a/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
@@ -4,9 +4,9 @@ import com.hcs.domain.Category;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@MybatisTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[MyBatisConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
 public class CategoryMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@MybatisTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[MyBatisConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
 class ClubMapperTest {
 
     @Autowired
@@ -167,15 +167,15 @@ class ClubMapperTest {
     @DisplayName("모든 클럽 수 세기")
     @ParameterizedTest
     @ValueSource(ints = {1, 5, 10})
-    void countByAllClubs(int givenClubSize){
+    void countByAllClubs(int givenClubSize) {
         //given
-        List<Club> givenClubList  = generateClubWithCategory(givenClubSize, 1);
+        List<Club> givenClubList = generateClubWithCategory(givenClubSize, 1);
 
         //when
         long totalClubCount = clubMapper.countByAllClubs();
 
         //then
-        assertEquals(givenClubSize,totalClubCount);
+        assertEquals(givenClubSize, totalClubCount);
     }
 
     private Set<User> generateAndJoinClub(Club club, UserType userType, int userSize) {

--- a/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
@@ -6,9 +6,9 @@ import com.hcs.domain.User;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@MybatisTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[MyBatisConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
 class CommentMapperTest {
 
     User testUser = new User(); // Dummy 데이터
@@ -93,7 +93,7 @@ class CommentMapperTest {
 
         String insertSql = "insert into Comment (authorId, tradePostId, contents)\n" +
                 "values (?, ?, ?)";
-        
+
         // 댓글 4개를 
         jdbcTemplate.update(insertSql, new Object[]{authorId, tradePostId, contents + 0});
         jdbcTemplate.update(insertSql, new Object[]{authorId, tradePostId, contents + 1});

--- a/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
@@ -4,9 +4,9 @@ import com.hcs.domain.TradePost;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@MybatisTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[MyBatisConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
 class TradePostMapperTest {
 
     @Autowired
@@ -84,6 +84,4 @@ class TradePostMapperTest {
         assertThat(returnedBy.get().getDescription()).isEqualTo(description);
         assertThat(returnedBy.get().getPrice()).isEqualTo(price);
     }
-
-
 }

--- a/api/src/test/java/com/hcs/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/UserMapperTest.java
@@ -4,9 +4,9 @@ import com.hcs.domain.User;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@MybatisTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[MyBatisConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
 class UserMapperTest {
 
     @Autowired


### PR DESCRIPTION
`Mybatis`의 트랜잭션 매니저가 `JPA`와의 혼용을 위해 `JpaTransactionManager`로 교체되었으며 해당 작업환경 마련을 위한 클래스들이 메모리에 올라와야 함.
이를 위해 `JPA` 단위테스트를 위해 필요한 빈들을 올려주는 `@DataJpaTest` 기존의 어노테이션인`@MybatisTest`와 교체하였음

<img width="322" alt="스크린샷 2022-01-13 오후 10 40 21" src="https://user-images.githubusercontent.com/58963724/149340717-f7c74227-1998-4dd6-be55-1acc20818549.png">

- 어노테이션 교체로 모든 테스트가 통과하고 있습니다
 