### PR TITLE
Club - modify 기능 추가

### DIFF
--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -8,8 +8,8 @@ import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsList;
-import com.hcs.dto.response.method.HcsSubmit;
 import com.hcs.dto.response.method.HcsModify;
+import com.hcs.dto.response.method.HcsSubmit;
 import com.hcs.service.CategoryService;
 import com.hcs.service.ClubService;
 import lombok.RequiredArgsConstructor;
@@ -65,8 +65,8 @@ public class ClubController {
     }
 
     @PostMapping("/modify")
-    public HcsResponse modifyClub(@RequestParam("clubId") long clubId, @RequestBody ClubSubmitDto clubDto){
-        clubId = clubService.modifyClub(clubId,clubDto);
+    public HcsResponse modifyClub(@RequestBody ClubSubmitDto clubDto, @RequestParam("clubId") long clubId) {
+        clubId = clubService.modifyClub(clubId, clubDto);
         String clubUrl = clubService.makeClubUrl(clubId);
         return responseManager.makeHcsResponse(hcsUpdate.club(clubId, clubUrl));
     }

--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -9,6 +9,7 @@ import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsList;
 import com.hcs.dto.response.method.HcsSubmit;
+import com.hcs.dto.response.method.HcsUpdate;
 import com.hcs.service.CategoryService;
 import com.hcs.service.ClubService;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ public class ClubController {
     private final HcsInfo info;
     private final HcsSubmit submit;
     private final HcsList hcsList;
+    private final HcsUpdate hcsUpdate;
     private final CategoryService categoryService;
 
     @PostMapping("/submit")
@@ -62,7 +64,12 @@ public class ClubController {
         return responseManager.makeHcsResponse(hcsList.club(clubInListDtos, page, count, allClubCounts));
     }
 
-    //TODO : delete club
+    @PostMapping("/modify")
+    public HcsResponse modifyClub(@RequestParam("clubId") long clubId, @RequestBody ClubSubmitDto clubDto){
+        clubId = clubService.modifyClub(clubId,clubDto);
+        String clubUrl = clubService.makeClubUrl(clubId);
+        return responseManager.makeHcsResponse(hcsUpdate.club(clubId, clubUrl));
+    }
 
     //TODO : update club
 

--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -9,7 +9,7 @@ import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsList;
 import com.hcs.dto.response.method.HcsSubmit;
-import com.hcs.dto.response.method.HcsUpdate;
+import com.hcs.dto.response.method.HcsModify;
 import com.hcs.service.CategoryService;
 import com.hcs.service.ClubService;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +37,7 @@ public class ClubController {
     private final HcsInfo info;
     private final HcsSubmit submit;
     private final HcsList hcsList;
-    private final HcsUpdate hcsUpdate;
+    private final HcsModify hcsUpdate;
     private final CategoryService categoryService;
 
     @PostMapping("/submit")

--- a/api/src/main/java/com/hcs/dto/request/ClubSubmitDto.java
+++ b/api/src/main/java/com/hcs/dto/request/ClubSubmitDto.java
@@ -6,8 +6,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
@@ -19,8 +17,6 @@ public class ClubSubmitDto {
     private String title;
     @Length(max = 50)
     private String description;
-    @NotNull
-    private LocalDateTime createdAt;
     @NotBlank
     private String location;
     @NotBlank

--- a/api/src/main/java/com/hcs/dto/response/method/HcsModify.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsModify.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class HcsUpdate {
+public class HcsModify {
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/api/src/main/java/com/hcs/dto/response/method/HcsUpdate.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsUpdate.java
@@ -1,0 +1,25 @@
+package com.hcs.dto.response.method;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HcsUpdate {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public ObjectNode club(long clubId, String clubUrl) {
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.createObjectNode();
+
+        item.put("clubId", clubId);
+        item.put("clubUrl", clubUrl);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+        return hcs;
+    }
+}

--- a/api/src/main/java/com/hcs/mapper/ClubMapper.java
+++ b/api/src/main/java/com/hcs/mapper/ClubMapper.java
@@ -21,8 +21,6 @@ public interface ClubMapper {
 
     void insertClub(Club club);
 
-    void deleteClubById(long id);
-
     Club findClubWithMembers(long id);
 
     Club findClubWithManagers(long id);
@@ -38,6 +36,8 @@ public interface ClubMapper {
     List<Club> findByPageAndCategory(long categoryId);
 
     long countByAllClubs();
+
+    void updateClub(Club club);
 
     //TODO: sort
 

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -60,7 +60,7 @@ public class ClubService {
         List<ClubInListDto> clubInListDtos = new ArrayList<>();
         for (Club c : clubList) {
             ClubInListDto dto = modelMapper.map(c, ClubInListDto.class);
-            dto.setClubUrl(domainUrl + "club/" + dto.getClubId());
+            dto.setClubUrl(makeClubUrl(dto.getClubId()));
             dto.setCategory(categoryService.getCategoryName(c.getCategoryId()));
             clubInListDtos.add(dto);
         }
@@ -75,7 +75,20 @@ public class ClubService {
         Club club = getClub(id);
         ClubInfoDto dto = modelMapper.map(club, ClubInfoDto.class);
         dto.setCategory(categoryService.getCategoryName(club.getCategoryId()));
-        dto.setClubUrl(domainUrl + "club/" + club.getId());
+        dto.setClubUrl(makeClubUrl(club.getId()));
         return dto;
+    }
+
+    public long modifyClub(long clubId, ClubSubmitDto clubDto) {
+        Club club = getClub(clubId);
+        club = modelMapper.map(clubDto, Club.class);
+        club.setCategoryId(categoryService.getCategoryId(clubDto.getCategory()));
+        club.setId(clubId);
+        clubMapper.updateClub(club);
+        return club.getId();
+    }
+
+    public String makeClubUrl(long clubId) {
+        return domainUrl + "club/" + clubId;
     }
 }

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,6 +32,7 @@ public class ClubService {
     public Club saveNewClub(@Valid ClubSubmitDto clubDto) {
         Club club = modelMapper.map(clubDto, Club.class);
         club.setCategoryId(categoryService.getCategoryId(clubDto.getCategory()));
+        club.setCreatedAt(LocalDateTime.now());
         try {
             clubMapper.insertClub(club);
         } catch (Exception e) {

--- a/api/src/main/resources/mybatis-mapper/ClubMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/ClubMapperXml.xml
@@ -21,12 +21,6 @@
         values (#{title}, #{description}, #{createdAt}, #{location}, #{categoryId})
     </insert>
 
-    <delete id="deleteClubById" parameterType="long">
-        delete
-        from Club
-        where HCS.Club.id = #{id}
-    </delete>
-
     <insert id="joinMemberById" parameterType="map">
         insert into club_members (clubId, memberId)
         values (#{clubId}, #{memberId})
@@ -101,5 +95,14 @@
         select COUNT(*)
         from Club
     </select>
+
+    <update id="updateClub" parameterType="com.hcs.domain.Club">
+        update Club
+        set title = #{title},
+            description = #{description},
+            location = #{location},
+            categoryId = #{categoryId}
+        where id = #{id}
+    </update>
 
 </mapper>

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -53,7 +53,6 @@ class ClubControllerTest {
         clubDto.setDescription("농구하고싶은사람 모여라");
         clubDto.setCategory("sports");
         clubDto.setLocation("Bucheon");
-        clubDto.setCreatedAt(LocalDateTime.now());
 
         mockMvc.perform(post("/club/submit")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
+++ b/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
@@ -14,8 +14,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
-import java.time.LocalDateTime;
-
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -41,13 +39,11 @@ class ClubDtoValidationTest {
         clubDto.setTitle("");
         clubDto.setCategory("sports");
         clubDto.setLocation("Bucheon");
-        clubDto.setCreatedAt(LocalDateTime.now());
 
         mockMvc.perform(post("/club/submit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(clubDto))
                         .accept(MediaType.APPLICATION_JSON))
-                //.with(csrf())) // security 설정 이후 코드 사용 예정
                 .andDo(print())
                 .andExpect(status().is4xxClientError())
                 .andExpect(

--- a/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
@@ -16,7 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
+        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
 public class CategoryMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
@@ -27,7 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]") ,
+        @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
 class ClubMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
@@ -27,7 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
+        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
 class CommentMapperTest {
 
     User testUser = new User(); // Dummy 데이터

--- a/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
@@ -18,7 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
+        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
 class TradePostMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/UserMapperTest.java
@@ -17,7 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
+        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
 class UserMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -162,4 +162,34 @@ class ClubServiceTest {
         assertEquals(clubInfoDto.getClubUrl(), domainUrl + "club/" + fixtureClub.getId());
 
     }
+
+    @DisplayName("저장되있는 club id 와 바꿀 정보 가 담긴 Dto 객체가 주어지면, update 한 club id 반환하기")
+    @Test
+    void modifyClub() {
+        //given
+        ClubSubmitDto clubDto = new ClubSubmitDto(
+                "modify title",
+                "description",
+                "location",
+                "sports"
+        );
+
+        Club modifiedClub = Club.builder()
+                .id(fixtureClub.getId())
+                .title(clubDto.getTitle())
+                .description(clubDto.getDescription())
+                .categoryId(1L)
+                .location(clubDto.getLocation())
+                .build();
+
+        given(categoryService.getCategoryId("sports")).willReturn(1L);
+        given(modelMapper.map(clubDto, Club.class)).willReturn(modifiedClub);
+        given(clubMapper.findById(anyLong())).willReturn(fixtureClub);
+
+        //when
+        long modifyClubId = clubService.modifyClub(fixtureClub.getId(), clubDto);
+
+        //then
+        assertEquals(modifyClubId, fixtureClub.getId());
+    }
 }

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -67,7 +67,6 @@ class ClubServiceTest {
         ClubSubmitDto correctClubDto = new ClubSubmitDto(
                 "club title",
                 "club description",
-                LocalDateTime.now(),
                 "test location",
                 "sports");
 


### PR DESCRIPTION
POST club/modify 기능을 추가했습니다. mapper, service, controller 테스트를 완료했습니다.

- `HcsModify` : modify 응답을 위한 객체 생성
- `ClubSubmitDto` : club 생성 및 modify 두가지 기능에 동시에 사용할 수 있도록 createdAt 필드 제거 
(service 단에서 도메인 객체로 바로 넣는것으로 변경)
- 기타 중복코드 리팩토링, 사용하지 않는 메소드제거