### PR TITLE
mapping columns with jpa in user, tradepost, comment domain

### DIFF
--- a/api/src/main/java/com/hcs/domain/Comment.java
+++ b/api/src/main/java/com/hcs/domain/Comment.java
@@ -6,13 +6,20 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
 @Data
+@Entity
+@Table(name = "Comment")
 @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
@@ -20,13 +27,28 @@ import java.util.Set;
 public class Comment {
 
     @EqualsAndHashCode.Include
+    @Id
+    @Column(name = "id")
     private long id;
 
+    @Column(name = "parentCommentId")
+    private long parentCommentId;
+
+    @ManyToOne
+    @JoinColumn(name = "authorId")
     private User author;
+
+    @Column(name = "contents")
     private String contents;
+
+    @ManyToOne
+    @JoinColumn(name = "tradePostId")
     private TradePost tradePost;
+
+    @OneToMany
+    @JoinColumn(name = "parentCommentId")
     private Set<Comment> replys = new HashSet<>();
 
-    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "registerationTime")
     private LocalDateTime registerationTime;
 }

--- a/api/src/main/java/com/hcs/domain/TradePost.java
+++ b/api/src/main/java/com/hcs/domain/TradePost.java
@@ -1,20 +1,26 @@
 package com.hcs.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
 @Data
+@Entity
+@Table(name = "TradePost")
 @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
@@ -22,25 +28,51 @@ import java.util.Set;
 public class TradePost {
 
     @EqualsAndHashCode.Include
-    @JsonIgnore
+    @Id
+    @Column(name = "id")
     private long id;
 
+    @Column(name = "title")
     private String title;
+
+    @ManyToOne
+    @JoinColumn(name = "authorId")
     private User author;
+
+    @Column(name = "productStatus")
     private String productStatus;
+
+    @Column(name = "category")
     private String category;
+
+    @Column(name = "description")
     private String description;
+
     @Lob
+    @Column(name = "pictures")
     private byte[] pictures;
+
+    @Column(name = "locationName")
     private String locationName;
+
+    @Column(name = "lng")
     private double lng;
+
+    @Column(name = "lat")
     private double lat;
+
+    @Column(name = "price")
     private int price;
+
+    @Column(name = "views")
     private int views;
 
+    @OneToMany(mappedBy = "tradePost")
     private Set<Comment> comments = new HashSet<>();
 
+    @Column(name = "salesStatus")
     private boolean salesStatus;
-    @Temporal(TemporalType.TIMESTAMP)
+
+    @Column(name = "registerationTime")
     private LocalDateTime registerationTime;
 }

--- a/api/src/main/java/com/hcs/domain/User.java
+++ b/api/src/main/java/com/hcs/domain/User.java
@@ -6,6 +6,11 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -16,6 +21,8 @@ import java.util.Set;
  */
 
 @Data
+@Entity
+@Table(name = "User")
 @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
@@ -23,16 +30,40 @@ import java.util.Set;
 public class User {
 
     @EqualsAndHashCode.Include
+    @Id
+    @Column(name = "id")
     private long id;
+
+    @Column(name = "email")
     private String email;
+
+    @Column(name = "nickname")
     private String nickname;
+
+    @Column(name = "password")
     private String password;
+
+    @Column(name = "emailVerified")
     private boolean emailVerified;
+
+    @Column(name = "emailCheckToken")
     private String emailCheckToken;
+
+    @Column(name = "emailCheckTokenGeneratedAt")
     private LocalDateTime emailCheckTokenGeneratedAt;
+
+    @Column(name = "joinedAt")
     private LocalDateTime joinedAt;
+
+    @Column(name = "age")
     private Integer age;
+
+    @Column(name = "position")
     private String position;
+
+    @Column(name = "location")
     private String location;
+
+    @OneToMany(mappedBy = "author")
     private Set<TradePost> tradePostList = new HashSet<>();
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
         format_sql: true
         implicit_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
         physical_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
-        hbm2ddl.auto: update
+        hbm2ddl.auto: none
     open-in-view: false
     show-sql: true
   redis:

--- a/api/src/main/resources/sql/commentCreate.sql
+++ b/api/src/main/resources/sql/commentCreate.sql
@@ -1,11 +1,13 @@
 create table Comment
 (
     id                int AUTO_INCREMENT PRIMARY KEY COMMENT '댓글 id key',
+    parentCommentId   int COMMENT '(대댓글일 경우) 부모 댓글 id key',
     authorId          int          NOT NULL,
     contents          VARCHAR(200) NOT NULL,
     tradePostId       int          NOT NULL,
     registerationTime datetime,
 
+    FOREIGN KEY (parentCommentId) REFERENCES Comment (id) ON DELETE CASCADE,
     FOREIGN KEY (authorId) REFERENCES User (id) ON DELETE CASCADE,
     FOREIGN KEY (tradePostId) REFERENCES TradePost (id) ON DELETE CASCADE
 )


### PR DESCRIPTION
User, TradePost, Comment 도메인 객체를 JPA에서 관리할 수 있도록 
Column을 기존의 테이블과 매핑시켰음

- Application 동작 시 DDL 기능을 끔
- `Comment`의 Reply와 1:N 연관관계를 맺기 위해 `parentCommentId` 컬럼을 추가하였음
`ALTER TABLE Comment ADD COLUMN parentCommentId int;`