### PR TITLE
Config - mapper test @DataJpaTest 설정변경

### DIFF
--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -7,8 +7,10 @@ import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
 import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.club.ClubInfoDto;
+import com.hcs.dto.response.club.ClubJoinDto;
 import com.hcs.dto.response.method.HcsDelete;
 import com.hcs.dto.response.method.HcsInfo;
+import com.hcs.dto.response.method.HcsJoin;
 import com.hcs.dto.response.method.HcsList;
 import com.hcs.dto.response.method.HcsModify;
 import com.hcs.dto.response.method.HcsSubmit;
@@ -43,6 +45,7 @@ public class ClubController {
     private final HcsList hcsList;
     private final HcsDelete hcsDelete;
     private final HcsModify hcsUpdate;
+    private final HcsJoin join;
     private final CategoryService categoryService;
     private final UserService userService;
 
@@ -80,9 +83,17 @@ public class ClubController {
     @DeleteMapping("/delete")
     public HcsResponse deleteClub(@RequestParam("clubId") long clubId, @RequestParam("userEmail") String userEmail) {
         //TODO : 보안 설정 후 userEmail 변경
-        User manager = userService.findByEmail(userEmail);
-        clubService.deleteClub(clubId, manager.getId());
+        User user = userService.findByEmail(userEmail);
+        clubService.deleteClub(clubId, user.getId());
         return responseManager.makeHcsResponse(hcsDelete.club(clubId));
+    }
+
+    @PostMapping("/members")
+    public HcsResponse joinClubAsMember(@RequestParam("clubId") long clubId, @RequestParam("userEmail") String userEmail) {
+        //TODO : 보안 설정 후 userEmail 변경
+        User user = userService.findByEmail(userEmail);
+        ClubJoinDto clubJoinDto = clubService.joinClub(clubId, user);
+        return responseManager.makeHcsResponse(join.club(clubJoinDto));
     }
 
 }

--- a/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
+++ b/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
@@ -4,7 +4,7 @@ import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
 import com.hcs.dto.response.method.HcsException;
 import com.hcs.exception.ErrorCode;
-import com.hcs.exception.club.AlreadyJoinedException;
+import com.hcs.exception.club.AlreadyJoinedClubException;
 import com.hcs.exception.club.ClubAccessDeniedException;
 import com.hcs.exception.global.DatabaseException;
 import com.hcs.exception.result.ExceptionResult;
@@ -69,9 +69,9 @@ public class ExceptionAdvisor {
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(AlreadyJoinedException.class)
+    @ExceptionHandler(AlreadyJoinedClubException.class)
     public HcsResponse alreadyJoinedExceptionHandler() {
-        ErrorCode error = ErrorCode.ALREADY_JOINED;
+        ErrorCode error = ErrorCode.ALREADY_JOINED_CLUB;
         return hcsResponseManager.makeHcsResponse(hcsException.exception(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage())));
     }
 

--- a/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
+++ b/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
@@ -4,6 +4,7 @@ import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
 import com.hcs.dto.response.method.HcsException;
 import com.hcs.exception.ErrorCode;
+import com.hcs.exception.club.AlreadyJoinedException;
 import com.hcs.exception.club.ClubAccessDeniedException;
 import com.hcs.exception.global.DatabaseException;
 import com.hcs.exception.result.ExceptionResult;
@@ -65,6 +66,13 @@ public class ExceptionAdvisor {
     public HcsResponse databaseExceptionHandler(DatabaseException e) {
         ErrorCode error = ErrorCode.DATABASE_ERROR;
         return hcsResponseManager.makeHcsResponse(hcsException.exceptionAndLocation(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage()), e.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(AlreadyJoinedException.class)
+    public HcsResponse alreadyJoinedExceptionHandler() {
+        ErrorCode error = ErrorCode.ALREADY_JOINED;
+        return hcsResponseManager.makeHcsResponse(hcsException.exception(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage())));
     }
 
     // TODO 추후 Response가 만들어지면 공통으로 처리될 error에 대한 전역적인 @ExceptionHandler 추가 작성될 것임.

--- a/api/src/main/java/com/hcs/dto/response/club/ClubJoinDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubJoinDto.java
@@ -1,0 +1,11 @@
+package com.hcs.dto.response.club;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ClubJoinDto {
+    Long applicantId;
+    Integer currentMembersCount;
+}

--- a/api/src/main/java/com/hcs/dto/response/method/HcsJoin.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsJoin.java
@@ -1,0 +1,27 @@
+package com.hcs.dto.response.method;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hcs.dto.response.club.ClubJoinDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HcsJoin {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    public ObjectNode club(ClubJoinDto dto){
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.createObjectNode();
+
+        ObjectNode member = objectMapper.valueToTree(dto);
+        item.set("member", member);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+
+        return hcs;
+    }
+}

--- a/api/src/main/java/com/hcs/exception/ErrorCode.java
+++ b/api/src/main/java/com/hcs/exception/ErrorCode.java
@@ -10,7 +10,9 @@ public enum ErrorCode {
     METHOD_ARGUMENT_NOT_VALID(400, -1, "request body로 전송된 데이터가 검증단계를 통과하지 못함"),
     NUMBER_FORMAT(400, -2, "숫자형으로 요청해주세요"),
     DATABASE_ERROR(500, -3, "db access error"),
-    CLUB_ACCESS_DENIED(400, -100, "해당 club 의 manager 만 접근이 가능합니다.");
+
+    CLUB_ACCESS_DENIED(400, -100, "해당 club 의 manager 만 접근이 가능합니다."),
+    ALREADY_JOINED(400, -101, "이미 club 에 등록한 user 입니다");
 
     private int status;
     private int errorCode;

--- a/api/src/main/java/com/hcs/exception/ErrorCode.java
+++ b/api/src/main/java/com/hcs/exception/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
     DATABASE_ERROR(500, -3, "db access error"),
 
     CLUB_ACCESS_DENIED(400, -100, "해당 club 의 manager 만 접근이 가능합니다."),
-    ALREADY_JOINED(400, -101, "이미 club 에 등록한 user 입니다");
+    ALREADY_JOINED_CLUB(400, -101, "이미 club 에 등록한 user 입니다");
 
     private int status;
     private int errorCode;

--- a/api/src/main/java/com/hcs/exception/club/AlreadyJoinedClubException.java
+++ b/api/src/main/java/com/hcs/exception/club/AlreadyJoinedClubException.java
@@ -1,0 +1,4 @@
+package com.hcs.exception.club;
+
+public class AlreadyJoinedClubException extends RuntimeException {
+}

--- a/api/src/main/java/com/hcs/exception/club/AlreadyJoinedException.java
+++ b/api/src/main/java/com/hcs/exception/club/AlreadyJoinedException.java
@@ -1,0 +1,4 @@
+package com.hcs.exception.club;
+
+public class AlreadyJoinedException extends RuntimeException {
+}

--- a/api/src/main/java/com/hcs/exception/club/AlreadyJoinedException.java
+++ b/api/src/main/java/com/hcs/exception/club/AlreadyJoinedException.java
@@ -1,4 +1,0 @@
-package com.hcs.exception.club;
-
-public class AlreadyJoinedException extends RuntimeException {
-}

--- a/api/src/main/java/com/hcs/mapper/ClubMapper.java
+++ b/api/src/main/java/com/hcs/mapper/ClubMapper.java
@@ -24,7 +24,9 @@ public interface ClubMapper {
 
     Club findClubWithManagers(long id);
 
-    void joinMemberById(@Param("clubId") long clubId, @Param("memberId") long userId);
+    Club findClubWithManagersAndMembers(long id);
+
+    int joinMemberById(@Param("clubId") long clubId, @Param("memberId") long userId);
 
     int joinManagerById(@Param("clubId") long clubId, @Param("managerId") long userId);
 
@@ -37,6 +39,12 @@ public interface ClubMapper {
     long countByAllClubs();
 
     void updateClub(Club club);
+
+    boolean checkClubManager(@Param("clubId") long clubId, @Param("managerId") long userId);
+
+    boolean checkClubMember(@Param("clubId") long clubId, @Param("memberId") long userId);
+
+    int updateMemberCount(@Param("id") long id, @Param("memberCount") int memberCount);
 
     //TODO: sort
 

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -6,7 +6,7 @@ import com.hcs.dto.request.ClubSubmitDto;
 import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.club.ClubJoinDto;
-import com.hcs.exception.club.AlreadyJoinedException;
+import com.hcs.exception.club.AlreadyJoinedClubException;
 import com.hcs.exception.club.ClubAccessDeniedException;
 import com.hcs.exception.global.DatabaseException;
 import com.hcs.mapper.ClubMapper;
@@ -124,7 +124,7 @@ public class ClubService {
     public void checkAlreadyJoinedClub(Club club, User user) {
         if (clubMapper.checkClubManager(club.getId(), user.getId()) ||
                 clubMapper.checkClubMember(club.getId(), user.getId())) {
-            throw new AlreadyJoinedException();
+            throw new AlreadyJoinedClubException();
         }
     }
 

--- a/api/src/main/resources/mybatis-mapper/ClubMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/ClubMapperXml.xml
@@ -110,10 +110,22 @@
         where id = #{id}
     </update>
 
-    <select id="checkClubManager" parameterType="long" resultType="int">
-        select COUNT(*)
+    <select id="checkClubManager" parameterType="long" resultType="boolean">
+        select IF(COUNT(*) = 1, 1, 0)
         from club_managers
         where clubId = #{clubId} AND managerId = #{managerId}
     </select>
+
+    <select id="checkClubMember" parameterType="long" resultType="boolean">
+        select IF(COUNT(*) = 1, 1, 0)
+        from club_members
+        where clubId = #{clubId} AND memberId = #{memberId}
+    </select>
+
+    <update id="updateMemberCount">
+        update club
+        set memberCount = #{memberCount}
+        where id = #{id}
+    </update>
 
 </mapper>

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -288,9 +288,9 @@ class ClubControllerTest {
                         .param("userEmail", user.getEmail())
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(jsonPath("$.HCS.item.errorCode").value(ErrorCode.ALREADY_JOINED.getErrorCode()))
-                .andExpect(jsonPath("$.HCS.item.message").value(ErrorCode.ALREADY_JOINED.getMessage()))
-                .andExpect(jsonPath("$.HCS.status").value(ErrorCode.ALREADY_JOINED.getStatus()));
+                .andExpect(jsonPath("$.HCS.item.errorCode").value(ErrorCode.ALREADY_JOINED_CLUB.getErrorCode()))
+                .andExpect(jsonPath("$.HCS.item.message").value(ErrorCode.ALREADY_JOINED_CLUB.getMessage()))
+                .andExpect(jsonPath("$.HCS.status").value(ErrorCode.ALREADY_JOINED_CLUB.getStatus()));
 
         //잘못된 요청 : 이미 가입한 manager
         mockMvc.perform(post("/club/members")
@@ -298,9 +298,9 @@ class ClubControllerTest {
                         .param("userEmail", manager.getEmail())
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(jsonPath("$.HCS.item.errorCode").value(ErrorCode.ALREADY_JOINED.getErrorCode()))
-                .andExpect(jsonPath("$.HCS.item.message").value(ErrorCode.ALREADY_JOINED.getMessage()))
-                .andExpect(jsonPath("$.HCS.status").value(ErrorCode.ALREADY_JOINED.getStatus()));
+                .andExpect(jsonPath("$.HCS.item.errorCode").value(ErrorCode.ALREADY_JOINED_CLUB.getErrorCode()))
+                .andExpect(jsonPath("$.HCS.item.message").value(ErrorCode.ALREADY_JOINED_CLUB.getMessage()))
+                .andExpect(jsonPath("$.HCS.status").value(ErrorCode.ALREADY_JOINED_CLUB.getStatus()));
     }
 
     private List<Club> generateClubBySizeAndCategoryId(int clubSize, long categoryId) {

--- a/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
@@ -16,8 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
-        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
 public class CategoryMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
@@ -27,8 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
-        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
 class CommentMapperTest {
 
     User testUser = new User(); // Dummy 데이터

--- a/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
@@ -18,8 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
-        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
 class TradePostMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/UserMapperTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
-        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
 class UserMapperTest {
 
     @Autowired
@@ -72,7 +71,6 @@ class UserMapperTest {
         assertThat(returnedBy.get().getNickname()).isEqualTo(newNickname);
         assertThat(returnedBy.get().getPassword()).isEqualTo(newPassword);
     }
-
 
     @DisplayName("UserMapper - insert 테스트")
     @Test


### PR DESCRIPTION
mapper test 에서 필요한 bean 스캔시 사용하는 정규표현식을 변경하였습니다.
기존에 사용하던 `DataSourceConfig` 와 datasource 암호화를 위한`JasyptConfig`만 포함시켰습니다.