### PR TITLE
Test Config - mapper test @DataJpaTest 의 설정수정

### DIFF
--- a/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CategoryMapperTest.java
@@ -16,8 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
-        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
 public class CategoryMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
@@ -27,8 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
-        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
 class CommentMapperTest {
 
     User testUser = new User(); // Dummy 데이터

--- a/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
@@ -18,8 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
-        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
 class TradePostMapperTest {
 
     @Autowired

--- a/api/src/test/java/com/hcs/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/UserMapperTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[DataSourceConfig]")
-        , @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*[Hcs].*")})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
 class UserMapperTest {
 
     @Autowired
@@ -72,7 +71,6 @@ class UserMapperTest {
         assertThat(returnedBy.get().getNickname()).isEqualTo(newNickname);
         assertThat(returnedBy.get().getPassword()).isEqualTo(newPassword);
     }
-
 
     @DisplayName("UserMapper - insert 테스트")
     @Test


### PR DESCRIPTION
mapper test 에서 필요한 bean 스캔시 사용하는 정규표현식을 변경하였습니다.
기존에 사용하던 `DataSourceConfig` 와 datasource 암호화를 위한`JasyptConfig`만 포함시켰습니다.