### PR TITLE
UserMapper 기능 생성 및 테스트 코드

### DIFF
--- a/api/src/main/java/com/hcs/config/DataSourceConfig.java
+++ b/api/src/main/java/com/hcs/config/DataSourceConfig.java
@@ -35,6 +35,9 @@ public class DataSourceConfig {
     @Value("${mybatis.mapper-locations}")
     private String mapperLocation;
 
+    @Value("${mybatis.config-location}")
+    private String configLocation;
+
     @Primary
     @Bean(name = "dataSource")
     @ConfigurationProperties(prefix = "spring.datasource.hikari")
@@ -75,6 +78,7 @@ public class DataSourceConfig {
         SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
         sqlSessionFactoryBean.setDataSource(dataSource);
         sqlSessionFactoryBean.setMapperLocations(new PathMatchingResourcePatternResolver().getResources(mapperLocation));
+        sqlSessionFactoryBean.setConfigLocation(new PathMatchingResourcePatternResolver().getResource(configLocation));
         return sqlSessionFactoryBean.getObject();
     }
 

--- a/api/src/main/java/com/hcs/mapper/UserMapper.java
+++ b/api/src/main/java/com/hcs/mapper/UserMapper.java
@@ -1,7 +1,6 @@
 package com.hcs.mapper;
 
 import com.hcs.domain.User;
-import com.hcs.domain.UserForJPA;
 import org.apache.ibatis.annotations.Mapper;
 
 /**
@@ -15,9 +14,15 @@ public interface UserMapper {
 
     User findByEmail(String email);
 
+    User findByNickname(String nickname);
+
+    int countByEmail(String email);
+
+    int countByNickname(String nickname);
+
     long insertUser(User user);
 
-    long deleteUserByEmail(String email);
+    int updateUser(User user);
 
-    UserForJPA findUserForJpaByEmail(String email);
+    long deleteUserById(long userId);
 }

--- a/api/src/main/java/com/hcs/service/UserService.java
+++ b/api/src/main/java/com/hcs/service/UserService.java
@@ -46,8 +46,7 @@ public class UserService {
         return userMapper.insertUser(user);
     }
 
-    public long deleteUserByEmail(String email) {
-        return userMapper.deleteUserByEmail(email);
+    public long deleteUserById(long userId) {
+        return userMapper.deleteUserById(userId);
     }
-
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -34,11 +34,11 @@ spring:
     host: localhost
     port: 6379
 
-
 mybatis:
   mapper-locations: classpath:mybatis-mapper/*.xml
   configuration:
     map-underscore-to-camel-case: true
+    call-setters-on-nulls: true
     log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
   type-aliases-package: com.hcs.domain
 

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -40,7 +40,7 @@ mybatis:
     map-underscore-to-camel-case: true
     call-setters-on-nulls: true
     log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
-  type-aliases-package: com.hcs.domain
+  config-location: classpath:mybatis-config/config.xml
 
 jasypt:
   encryptor:

--- a/api/src/main/resources/mybatis-config/config.xml
+++ b/api/src/main/resources/mybatis-config/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0/EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <typeAliases>
+        <typeAlias alias="User" type="com.hcs.domain.User"/>
+        <typeAlias alias="UserForJPA" type="com.hcs.domain.UserForJPA"/>
+    </typeAliases>
+</configuration>

--- a/api/src/main/resources/mybatis-mapper/UserMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/UserMapperXml.xml
@@ -15,22 +15,56 @@
         where email = #{email}
     </select>
 
-    <insert id="insertUser" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.User">
-        insert into User (email, nickname, password, emailVerified, emailCheckToken, emailCheckTokenGeneratedAt,
-                          joinedAt, age, position, location)
-        values (#{email}, #{nickname}, #{password}, #{emailVerified}, #{emailCheckToken}, #{emailCheckTokenGeneratedAt},
-                #{joinedAt}, #{age}, #{position}, #{location})
-    </insert>
-
-    <delete id="deleteUserByEmail" parameterType="String">
-        delete
+    <select id="findByNickname" parameterType="String" resultType="com.hcs.domain.User">
+        select *
         from User
-        where HCS.User.email = #{email}
-    </delete>
+        where nickname = #{nickname}
+    </select>
 
     <select id="findUserForJpaByEmail" parameterType="String" resultType="com.hcs.domain.UserForJPA">
+
+
         select *
         from user_forjpa
         where email = #{email}
     </select>
+
+    <select id="countByEmail" parameterType="String" resultType="int">
+        select COUNT(*)
+        from User
+        where email = #{email}
+    </select>
+
+    <select id="countByNickname" parameterType="String" resultType="int">
+        select COUNT(*)
+        from User
+        where nickname = #{nickname}
+    </select>
+
+    <insert id="insertUser" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.User">
+        insert into User (email, nickname, password, emailVerified, emailCheckToken, emailCheckTokenGeneratedAt,
+        joinedAt, age, position, location)
+        values (#{email}, #{nickname}, #{password}, #{emailVerified}, #{emailCheckToken}, #{emailCheckTokenGeneratedAt},
+        #{joinedAt}, #{age}, #{position}, #{location})
+        <selectKey keyProperty="id" resultType="long" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
+    </insert>
+
+    <update id="updateUser" parameterType="com.hcs.domain.User">
+        update User
+        set email    = #{email},
+            nickname = #{nickname},
+            password = #{password},
+            age      = #{age},
+            position = #{position},
+            location = #{location}
+        where id = #{id}
+    </update>
+
+    <delete id="deleteUserById" parameterType="long">
+        delete
+        from User
+        where HCS.User.id = #{id}
+    </delete>
 </mapper>

--- a/api/src/main/resources/mybatis-mapper/UserMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/UserMapperXml.xml
@@ -3,25 +3,25 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.hcs.mapper.UserMapper">
-    <select id="findById" parameterType="long" resultType="com.hcs.domain.User">
+    <select id="findById" parameterType="long" resultType="User">
         select *
         from User
         where id = #{userId}
     </select>
 
-    <select id="findByEmail" parameterType="String" resultType="com.hcs.domain.User">
+    <select id="findByEmail" parameterType="String" resultType="User">
         select *
         from User
         where email = #{email}
     </select>
 
-    <select id="findByNickname" parameterType="String" resultType="com.hcs.domain.User">
+    <select id="findByNickname" parameterType="String" resultType="User">
         select *
         from User
         where nickname = #{nickname}
     </select>
 
-    <select id="findUserForJpaByEmail" parameterType="String" resultType="com.hcs.domain.UserForJPA">
+    <select id="findUserForJpaByEmail" parameterType="String" resultType="UserForJPA">
         select *
         from user_forjpa
         where email = #{email}
@@ -39,7 +39,7 @@
         where nickname = #{nickname}
     </select>
 
-    <insert id="insertUser" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.User">
+    <insert id="insertUser" useGeneratedKeys="true" keyProperty="id" parameterType="User">
         insert into User (email, nickname, password, emailVerified, emailCheckToken, emailCheckTokenGeneratedAt,
         joinedAt, age, position, location)
         values (#{email}, #{nickname}, #{password}, #{emailVerified}, #{emailCheckToken}, #{emailCheckTokenGeneratedAt},
@@ -49,7 +49,7 @@
         </selectKey>
     </insert>
 
-    <update id="updateUser" parameterType="com.hcs.domain.User">
+    <update id="updateUser" parameterType="User">
         update User
         set email    = #{email},
             nickname = #{nickname},

--- a/api/src/main/resources/mybatis-mapper/UserMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/UserMapperXml.xml
@@ -22,8 +22,6 @@
     </select>
 
     <select id="findUserForJpaByEmail" parameterType="String" resultType="com.hcs.domain.UserForJPA">
-
-
         select *
         from user_forjpa
         where email = #{email}

--- a/api/src/test/java/com/hcs/common/JdbcTemplateHelper.java
+++ b/api/src/test/java/com/hcs/common/JdbcTemplateHelper.java
@@ -1,0 +1,35 @@
+package com.hcs.common;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Component;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+
+@Component
+public class JdbcTemplateHelper {
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    public long insertTestUser(String newEmail, String newNickname, String newPassword) {
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        String insertSql = "insert into User (email, nickname, password)\n" +
+                "values (?, ?, ?)";
+
+        jdbcTemplate.update(con -> {
+            PreparedStatement ps = con.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS);
+            ps.setString(1, newEmail);
+            ps.setString(2, newNickname);
+            ps.setString(3, newPassword);
+            return ps;
+        }, keyHolder);
+
+        return keyHolder.getKey().longValue();
+    }
+}

--- a/api/src/test/java/com/hcs/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/UserMapperTest.java
@@ -1,5 +1,6 @@
 package com.hcs.mapper;
 
+import com.hcs.common.JdbcTemplateHelper;
 import com.hcs.domain.User;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
@@ -9,44 +10,21 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
 
-import java.sql.PreparedStatement;
-import java.sql.Statement;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig", ".*Helper"})})
 class UserMapperTest {
 
     @Autowired
     UserMapper userMapper;
 
     @Autowired
-    JdbcTemplate jdbcTemplate;
-
-    long insertTestUser(String newEmail, String newNickname, String newPassword) {
-
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-
-        String insertSql = "insert into User (email, nickname, password)\n" +
-                "values (?, ?, ?)";
-
-        jdbcTemplate.update(con -> {
-            PreparedStatement ps = con.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS);
-            ps.setString(1, newEmail);
-            ps.setString(2, newNickname);
-            ps.setString(3, newPassword);
-            return ps;
-        }, keyHolder);
-
-        return keyHolder.getKey().longValue();
-    }
+    JdbcTemplateHelper jdbcTemplateHelper;
 
     @DisplayName("UserMapper - 사용자 Id(DB의 Prmiary Key)로 User 찾기")
     @Test
@@ -56,7 +34,7 @@ class UserMapperTest {
         String newNickname = "test";
         String newPassword = "password";
 
-        long userId = insertTestUser(newEmail, newNickname, newPassword);
+        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
 
         Optional<User> returnedBy = Optional.ofNullable(userMapper.findById(userId));
 
@@ -74,7 +52,7 @@ class UserMapperTest {
         String newNickname = "test";
         String newPassword = "password";
 
-        insertTestUser(newEmail, newNickname, newPassword);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
 
         Optional<User> returnedBy = Optional.ofNullable(userMapper.findByEmail(newEmail));
 
@@ -92,7 +70,7 @@ class UserMapperTest {
         String newNickname = "test";
         String newPassword = "password";
 
-        insertTestUser(newEmail, newNickname, newPassword);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
 
         Optional<User> returnedBy = Optional.ofNullable(userMapper.findByNickname(newNickname));
 
@@ -110,9 +88,9 @@ class UserMapperTest {
         String newNickname = "test";
         String newPassword = "password";
 
-        insertTestUser(newEmail, newNickname, newPassword);
-        insertTestUser(newEmail, newNickname + 1, newPassword + 1);
-        insertTestUser(newEmail, newNickname + 2, newPassword + 2);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname + 1, newPassword + 1);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname + 2, newPassword + 2);
 
         int count = userMapper.countByEmail(newEmail);
 
@@ -127,9 +105,9 @@ class UserMapperTest {
         String newNickname = "test";
         String newPassword = "password";
 
-        insertTestUser(newEmail, newNickname, newPassword);
-        insertTestUser(newEmail + 1, newNickname, newPassword + 1);
-        insertTestUser(newEmail + 2, newNickname, newPassword + 2);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        jdbcTemplateHelper.insertTestUser(newEmail + 1, newNickname, newPassword + 1);
+        jdbcTemplateHelper.insertTestUser(newEmail + 2, newNickname, newPassword + 2);
 
         int count = userMapper.countByNickname(newNickname);
 
@@ -163,7 +141,7 @@ class UserMapperTest {
         String newNickname = "test2";
         String newPassword = "password";
 
-        long userId = insertTestUser(newEmail, newNickname, newPassword);
+        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
 
         int age = 20;
         String position = "backend";
@@ -192,7 +170,7 @@ class UserMapperTest {
         String newNickname = "test";
         String newPassword = "password";
 
-        long userId = insertTestUser(newEmail, newNickname, newPassword);
+        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
         long isSuccess = userMapper.deleteUserById(userId);
 
         assertThat(isSuccess).isGreaterThan(0);

--- a/api/src/test/java/com/hcs/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/UserMapperTest.java
@@ -10,7 +10,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 
+import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,12 +30,40 @@ class UserMapperTest {
     @Autowired
     JdbcTemplate jdbcTemplate;
 
-    void insertTestUser(String newEmail, String newNickname, String newPassword) {
+    long insertTestUser(String newEmail, String newNickname, String newPassword) {
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
 
         String insertSql = "insert into User (email, nickname, password)\n" +
                 "values (?, ?, ?)";
 
-        jdbcTemplate.update(insertSql, new Object[]{newEmail, newNickname, newPassword});
+        jdbcTemplate.update(con -> {
+            PreparedStatement ps = con.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS);
+            ps.setString(1, newEmail);
+            ps.setString(2, newNickname);
+            ps.setString(3, newPassword);
+            return ps;
+        }, keyHolder);
+
+        return keyHolder.getKey().longValue();
+    }
+
+    @DisplayName("UserMapper - 사용자 Id(DB의 Prmiary Key)로 User 찾기")
+    @Test
+    void findByIdTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long userId = insertTestUser(newEmail, newNickname, newPassword);
+
+        Optional<User> returnedBy = Optional.ofNullable(userMapper.findById(userId));
+
+        assertThat(returnedBy).isNotEmpty();
+        assertThat(returnedBy.get().getEmail()).isEqualTo(newEmail);
+        assertThat(returnedBy.get().getNickname()).isEqualTo(newNickname);
+        assertThat(returnedBy.get().getPassword()).isEqualTo(newPassword);
     }
 
     @DisplayName("UserMapper - 이메일로 User 찾기")
@@ -50,12 +82,11 @@ class UserMapperTest {
         assertThat(returnedBy.get().getEmail()).isEqualTo(newEmail);
         assertThat(returnedBy.get().getNickname()).isEqualTo(newNickname);
         assertThat(returnedBy.get().getPassword()).isEqualTo(newPassword);
-
     }
 
-    @DisplayName("UserMapper - 사용자 Id(DB의 Prmiary Key)로 User 찾기")
+    @DisplayName("UserMapper - 닉네임으로 User 찾기")
     @Test
-    void findByIdTest() {
+    void findByNicknameTest() {
 
         String newEmail = "test@naver.com";
         String newNickname = "test";
@@ -63,13 +94,46 @@ class UserMapperTest {
 
         insertTestUser(newEmail, newNickname, newPassword);
 
-        Optional<User> insertedUser = Optional.ofNullable(userMapper.findByEmail(newEmail));
-        Optional<User> returnedBy = Optional.ofNullable(userMapper.findById(insertedUser.get().getId()));
+        Optional<User> returnedBy = Optional.ofNullable(userMapper.findByNickname(newNickname));
 
         assertThat(returnedBy).isNotEmpty();
         assertThat(returnedBy.get().getEmail()).isEqualTo(newEmail);
         assertThat(returnedBy.get().getNickname()).isEqualTo(newNickname);
         assertThat(returnedBy.get().getPassword()).isEqualTo(newPassword);
+    }
+
+    @DisplayName("UserMapper - 이메일로 User 수 찾기")
+    @Test
+    void countByEmailTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        insertTestUser(newEmail, newNickname, newPassword);
+        insertTestUser(newEmail, newNickname + 1, newPassword + 1);
+        insertTestUser(newEmail, newNickname + 2, newPassword + 2);
+
+        int count = userMapper.countByEmail(newEmail);
+
+        assertThat(count).isEqualTo(3);
+    }
+
+    @DisplayName("UserMapper - 닉네임으로 User 수 찾기")
+    @Test
+    void countByNicknameTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        insertTestUser(newEmail, newNickname, newPassword);
+        insertTestUser(newEmail + 1, newNickname, newPassword + 1);
+        insertTestUser(newEmail + 2, newNickname, newPassword + 2);
+
+        int count = userMapper.countByNickname(newNickname);
+
+        assertThat(count).isEqualTo(3);
     }
 
     @DisplayName("UserMapper - insert 테스트")
@@ -86,19 +150,51 @@ class UserMapperTest {
                 .password(newPassword)
                 .build();
 
-        long newUserId = userMapper.insertUser(testUser);
+        userMapper.insertUser(testUser);
 
-        assertThat(newUserId).isGreaterThan(0);
+        assertThat(testUser.getId()).isGreaterThan(0);
+    }
+
+    @DisplayName("UserMapper - update 테스트")
+    @Test
+    void updateUserTest() {
+
+        String newEmail = "test2@naver.com";
+        String newNickname = "test2";
+        String newPassword = "password";
+
+        long userId = insertTestUser(newEmail, newNickname, newPassword);
+
+        int age = 20;
+        String position = "backend";
+        String location = "Seoul";
+
+        User modifiedUser = User.builder()
+                .id(userId)
+                .email(newEmail + 1)
+                .nickname(newNickname + 1)
+                .password(newPassword + 1)
+                .age(age)
+                .position(position)
+                .location(location)
+                .build();
+
+        int isSuccess = userMapper.updateUser(modifiedUser);
+
+        assertThat(isSuccess).isGreaterThan(0);
     }
 
     @DisplayName("UserMapper - delete 테스트")
     @Test
-    void deleteUserByEmailTest() {
+    void deleteUserByIdTest() {
 
-        String existingUserEmail = "test2@naver.com";
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
 
-        long deletedUserId = userMapper.deleteUserByEmail(existingUserEmail);
+        long userId = insertTestUser(newEmail, newNickname, newPassword);
+        long isSuccess = userMapper.deleteUserById(userId);
 
-        assertThat(deletedUserId).isGreaterThan(0);
+        assertThat(isSuccess).isGreaterThan(0);
     }
 }


### PR DESCRIPTION
`User` 테이블의 `mapper` 기능을 생성 및 테스트 하였음

생성된 기능
- `findByNickname()`
- `countByEmail()`, `countByNickname()` : User 정보의 수정시에 넘어오는 값을 검증할때 사용됨
- `updateUser()`
- `deleteUserById()`

추가시킨 기능
- `insertUser()` : `selectKey` 기능을 추가함. (삽입된 row의 java object에 id값이 추가하는 기능)

삭제된 기능
- `deleteUserByEmail()` : `deleteUserById()` 로 대체됨

모든 테스트를 통과하였음
<img width="499" alt="스크린샷 2022-01-18 오후 4 29 59" src="https://user-images.githubusercontent.com/58963724/149891955-092d7369-2bac-4aaf-b58f-1173791a9ed6.png">

- 해당 테스트들은 `mybatis`의 쿼리문을 질의 시 리턴하는 값을 가지고 기능을 테스트하였음
<img width="779" alt="스크린샷 2022-01-18 오전 3 42 18" src="https://user-images.githubusercontent.com/58963724/149892075-7df5a47a-a77a-4806-9062-455296fb1cd4.png">

+) `typeAliasesPackage` 기능으로 `resultType` 지정 시 별명값으로 줄 수 있도록 `config.xml` 파일과 `DataSourceConfig` 파일 추가
+) 테스트를 위해 쓰이는 `jdbcTemplate` (삽입 쿼리) `method`는 따로 `helper` 클래스를 만들어 빈으로 등록함