### PR TITLE
TradePostMapper 기능 생성 및 테스트 코드

### DIFF
--- a/api/src/main/java/com/hcs/controller/ChatRoomController.java
+++ b/api/src/main/java/com/hcs/controller/ChatRoomController.java
@@ -1,7 +1,6 @@
 package com.hcs.controller;
 
 import com.hcs.domain.ChatRoom;
-import com.hcs.domain.TradePost;
 import com.hcs.domain.User;
 import com.hcs.dto.response.HcsResponse;
 import com.hcs.dto.response.HcsResponseManager;
@@ -31,21 +30,21 @@ public class ChatRoomController {
     @PostMapping("/room/submit")
     public HcsResponse createChatRoom(@RequestParam("userId") long userId, @RequestParam(name = "tradePostId", required = false) long saleTradePostId) {
 
+        Long sellerId = tradePostService.findAuthorIdById(saleTradePostId);
         User user = userService.findById(userId);
-        TradePost saleTradePost = tradePostService.findById(saleTradePostId);
+        User seller = userService.findById(sellerId);
 
         ChatRoom newRoom = ChatRoom.create();
 
-        if (saleTradePost == null) {
+        if (sellerId == null) {
             chatRoomService.createChatRoom(newRoom, user); // 기본 DM창에서 방을 생성할 경우
             // TODO 초대한 상대방에게 알람 날리기
         } else {
-            chatRoomService.createChatRoom(newRoom, user, saleTradePost.getAuthor()); // 중고거래 게시물의 "판매자와 채팅" 버튼으로 방을 생성할 경우
+            chatRoomService.createChatRoom(newRoom, user, seller); // 중고거래 게시물의 "판매자와 채팅" 버튼으로 방을 생성할 경우
         }
 
         // TODO 구매자에게 알람 날리기 : 구매자는 알람을 통해 자신의 기본 DM창으로 이동할 수 있음
 
         return hcsResponseManager.makeHcsResponse(submit.chatRoom(newRoom.getId()));
     }
-
 }

--- a/api/src/main/java/com/hcs/domain/TradePost.java
+++ b/api/src/main/java/com/hcs/domain/TradePost.java
@@ -30,7 +30,7 @@ public class TradePost {
     @EqualsAndHashCode.Include
     @Id
     @Column(name = "id")
-    private long id;
+    private Long id;
 
     @Column(name = "title")
     private String title;
@@ -62,16 +62,16 @@ public class TradePost {
     private double lat;
 
     @Column(name = "price")
-    private int price;
+    private Integer price;
 
     @Column(name = "views")
-    private int views;
+    private Integer views;
 
     @OneToMany(mappedBy = "tradePost")
     private Set<Comment> comments = new HashSet<>();
 
     @Column(name = "salesStatus")
-    private boolean salesStatus;
+    private Boolean salesStatus;
 
     @Column(name = "registerationTime")
     private LocalDateTime registerationTime;

--- a/api/src/main/java/com/hcs/mapper/TradePostMapper.java
+++ b/api/src/main/java/com/hcs/mapper/TradePostMapper.java
@@ -10,9 +10,11 @@ public interface TradePostMapper {
 
     TradePost findByTitle(String title);
 
-    void insert(TradePost tradePost);
+    Long findAuthorIdById(long tradePostId);
 
-    void deleteById(long Id);
+    long insertTradePost(TradePost tradePost);
+
+    int deleteTradePostById(long tradePostId);
 
     // TODO 글쓴이의 이름 가져오기
 }

--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -25,4 +25,7 @@ public class TradePostService {
         return tradePostMapper.findById(Id);
     }
 
+    public Long findAuthorIdById(long Id) {
+        return tradePostMapper.findAuthorIdById(Id);
+    }
 }

--- a/api/src/main/resources/mybatis-config/config.xml
+++ b/api/src/main/resources/mybatis-config/config.xml
@@ -6,5 +6,6 @@
     <typeAliases>
         <typeAlias alias="User" type="com.hcs.domain.User"/>
         <typeAlias alias="UserForJPA" type="com.hcs.domain.UserForJPA"/>
+        <typeAlias alias="TradePost" type="com.hcs.domain.TradePost"/>
     </typeAliases>
 </configuration>

--- a/api/src/main/resources/mybatis-mapper/TradePostMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/TradePostMapperXml.xml
@@ -3,31 +3,37 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.hcs.mapper.TradePostMapper">
-    <cache/>
-
-    <select id="findByTitle" parameterType="String" resultType="com.hcs.domain.TradePost">
+    <select id="findById" parameterType="long" resultType="TradePost">
         select *
         from TradePost
-        where title = #{title}
+        where id = #{id}
     </select>
 
-    <select id="findById" parameterType="long" resultType="com.hcs.domain.TradePost">
+    <select id="findByTitle" parameterType="String" resultType="TradePost">
         select *
         from TradePost
-        where id = #{Id}
+        where title = #{id}
     </select>
 
-    <insert id="insert" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.TradePost">
+    <select id="findAuthorIdById" parameterType="long" resultType="Long">
+        select authorId
+        from TradePost
+        where id = #{id}
+    </select>
+
+    <insert id="insertTradePost" useGeneratedKeys="true" keyProperty="id" parameterType="TradePost">
         insert into TradePost (authorId, title, productStatus, category, description,
-                               pictures, locationName, lat, lng, price, salesStatus, registerationTime)
-        values (#{authorId}, #{title}, #{productStatus}, #{category}, #{description},
-                #{pictures}, #{locationName}, #{lat}, #{lng}, #{price}, #{salesStatus}, #{registerationTime})
+        pictures, locationName, lat, lng, price, salesStatus, registerationTime)
+        values (#{author.id}, #{title}, #{productStatus}, #{category}, #{description},
+        #{pictures}, #{locationName}, #{lat}, #{lng}, #{price}, #{salesStatus}, #{registerationTime})
+        <selectKey keyProperty="id" resultType="long" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
     </insert>
 
-    <delete id="delete" parameterType="String">
+    <delete id="deleteTradePostById" parameterType="long">
         delete
         from TradePost
-        where title = #{title}
+        where id = #{id}
     </delete>
-
 </mapper>

--- a/api/src/main/resources/sql/tradePostCreate.sql
+++ b/api/src/main/resources/sql/tradePostCreate.sql
@@ -12,7 +12,7 @@ create table TradePost
     lat               DECIMAL(16, 14),
     price             int          NOT NULL,
     views             int          NOT NULL DEFAULT 0,
-    salesStatus       boolean      NOT NULL DEFAULT 0,
+    salesStatus       boolean      NOT NULL,
     registerationTime datetime     NOT NULL,
 
     FOREIGN KEY (authorId) REFERENCES User (id) ON DELETE CASCADE

--- a/api/src/test/java/com/hcs/common/JdbcTemplateHelper.java
+++ b/api/src/test/java/com/hcs/common/JdbcTemplateHelper.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
+import java.time.LocalDateTime;
 
 @Component
 public class JdbcTemplateHelper {
@@ -27,6 +28,29 @@ public class JdbcTemplateHelper {
             ps.setString(1, newEmail);
             ps.setString(2, newNickname);
             ps.setString(3, newPassword);
+            return ps;
+        }, keyHolder);
+
+        return keyHolder.getKey().longValue();
+    }
+
+    public long insertTestTradePost(long authorId, String title, String productStatus, String category, String description, int price, int salesStatus, LocalDateTime registerationTime) {
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        String insertSql = "insert into TradePost (authorId, title, productStatus, category, description, price, salesStatus, registerationTime)\n" +
+                "values (?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.update(con -> {
+            PreparedStatement ps = con.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS);
+            ps.setString(1, String.valueOf(authorId));
+            ps.setString(2, title);
+            ps.setString(3, productStatus);
+            ps.setString(4, category);
+            ps.setString(5, description);
+            ps.setString(6, String.valueOf(price));
+            ps.setString(7, String.valueOf(salesStatus));
+            ps.setString(8, String.valueOf(registerationTime));
             return ps;
         }, keyHolder);
 

--- a/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
@@ -1,6 +1,8 @@
 package com.hcs.mapper;
 
+import com.hcs.common.JdbcTemplateHelper;
 import com.hcs.domain.TradePost;
+import com.hcs.domain.User;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,7 +11,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -18,70 +19,184 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableEncryptableProperties
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig"})})
+@DataJpaTest(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = {".*DataSourceConfig", ".*JasyptConfig", ".*Helper"})})
 class TradePostMapperTest {
+
+    @Autowired
+    UserMapper userMapper;
 
     @Autowired
     TradePostMapper tradePostMapper;
 
     @Autowired
-    JdbcTemplate jdbcTemplate;
-
-    void insertTestTradePost(long authorId, String title, String productStatus, String category, String description, int price, LocalDateTime registerationTime) {
-
-        String insertSql = "insert into TradePost (authorId, title, productStatus, category, description, price, registerationTime)\n" +
-                "values (?, ?, ?, ?, ?, ?, ?)";
-
-        jdbcTemplate.update(insertSql, new Object[]{authorId, title, productStatus, category, description, price, registerationTime});
-    }
-
-
-    @DisplayName("TradePostMapper - Title로 TradePost 찾기")
-    @Test
-    void findByTitleTest() {
-
-        long authorId = 43;
-        String title = "test";
-        String productStatus = "중";
-        String category = "중";
-        String description = "중";
-        int price = 10000;
-        LocalDateTime registrationTime = LocalDateTime.now();
-
-        insertTestTradePost(authorId, title, productStatus, category, description, price, registrationTime);
-
-        Optional<TradePost> returnedBy = Optional.ofNullable(tradePostMapper.findByTitle(title));
-
-        assertThat(returnedBy).isNotEmpty();
-        assertThat(returnedBy.get().getTitle()).isEqualTo(title);
-        assertThat(returnedBy.get().getProductStatus()).isEqualTo(productStatus);
-        assertThat(returnedBy.get().getCategory()).isEqualTo(category);
-        assertThat(returnedBy.get().getDescription()).isEqualTo(description);
-        assertThat(returnedBy.get().getPrice()).isEqualTo(price);
-    }
+    JdbcTemplateHelper jdbcTemplateHelper;
 
     @DisplayName("TradePostMapper - Id로 TradePost 찾기")
     @Test
     void findByIdTest() {
 
-        long authorId = 43;
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
         String title = "test";
         String productStatus = "중";
         String category = "중";
         String description = "중";
         int price = 10000;
+        int salesStatus = 0;
         LocalDateTime registrationTime = LocalDateTime.now();
 
-        insertTestTradePost(authorId, title, productStatus, category, description, price, registrationTime);
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
 
-        Optional<TradePost> insertedTradePost = Optional.ofNullable(tradePostMapper.findByTitle(title));
-        Optional<TradePost> returnedBy = Optional.ofNullable(tradePostMapper.findById(insertedTradePost.get().getId()));
+        Optional<TradePost> returnedBy = Optional.ofNullable(tradePostMapper.findById(tradePostId));
 
         assertThat(returnedBy).isNotEmpty();
+        assertThat(returnedBy.get().getId()).isEqualTo(tradePostId);
         assertThat(returnedBy.get().getTitle()).isEqualTo(title);
         assertThat(returnedBy.get().getProductStatus()).isEqualTo(productStatus);
         assertThat(returnedBy.get().getCategory()).isEqualTo(category);
         assertThat(returnedBy.get().getDescription()).isEqualTo(description);
         assertThat(returnedBy.get().getPrice()).isEqualTo(price);
+    }
+
+    @DisplayName("TradePostMapper - Title로 TradePost 찾기")
+    @Test
+    void findByTitleTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        Optional<TradePost> returnedBy = Optional.ofNullable(tradePostMapper.findByTitle(title));
+
+        assertThat(returnedBy).isNotEmpty();
+        assertThat(returnedBy.get().getId()).isEqualTo(tradePostId);
+        assertThat(returnedBy.get().getTitle()).isEqualTo(title);
+        assertThat(returnedBy.get().getProductStatus()).isEqualTo(productStatus);
+        assertThat(returnedBy.get().getCategory()).isEqualTo(category);
+        assertThat(returnedBy.get().getDescription()).isEqualTo(description);
+        assertThat(returnedBy.get().getPrice()).isEqualTo(price);
+    }
+
+    @DisplayName("TradePostMapper - Id로 글쓴이 찾기")
+    @Test
+    void findAuthorByTradePostIdTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+        Long returnedAuthorId = tradePostMapper.findAuthorIdById(tradePostId);
+
+        Optional<User> returnedBy = Optional.ofNullable(userMapper.findById(returnedAuthorId));
+
+        assertThat(returnedBy).isNotEmpty();
+        assertThat(returnedBy.get().getId()).isEqualTo(authorId);
+        assertThat(returnedBy.get().getEmail()).isEqualTo(newEmail);
+        assertThat(returnedBy.get().getNickname()).isEqualTo(newNickname);
+        assertThat(returnedBy.get().getPassword()).isEqualTo(newPassword);
+
+        // TradePost의 Author가 아닌 경우
+        Optional<User> returnedBy2 = Optional.ofNullable(userMapper.findById(returnedAuthorId + 1));
+
+        assertThat(returnedBy2).isEmpty();
+    }
+
+    @DisplayName("TradePostMapper - TradePost 삽입하기")
+    @Test
+    void insertTradePostTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        User author = userMapper.findById(authorId);
+        author.setId(authorId);
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        boolean salesStatus = false;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        TradePost tradePost = TradePost.builder()
+                .title(title)
+                .productStatus(productStatus)
+                .category(category)
+                .description(description)
+                .price(price)
+                .salesStatus(salesStatus)
+                .registerationTime(registrationTime)
+                .author(author)
+                .build();
+
+        tradePostMapper.insertTradePost(tradePost);
+
+        long tradePostId = tradePost.getId();
+
+        Optional<TradePost> returnedBy = Optional.ofNullable(tradePostMapper.findById(tradePostId));
+
+        assertThat(returnedBy).isNotEmpty();
+        assertThat(returnedBy.get().getId()).isEqualTo(tradePostId);
+        assertThat(returnedBy.get().getTitle()).isEqualTo(title);
+        assertThat(returnedBy.get().getProductStatus()).isEqualTo(productStatus);
+        assertThat(returnedBy.get().getCategory()).isEqualTo(category);
+        assertThat(returnedBy.get().getDescription()).isEqualTo(description);
+        assertThat(returnedBy.get().getPrice()).isEqualTo(price);
+    }
+
+    @DisplayName("TradePostMapper - Id로 TradePost 삭제하기")
+    @Test
+    void deleteTradePostByIdTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        Optional<TradePost> returnedBy = Optional.ofNullable(tradePostMapper.findById(tradePostId));
+
+        assertThat(returnedBy).isNotEmpty();
+
+        int isSuccess = tradePostMapper.deleteTradePostById(tradePostId);
+
+        assertThat(isSuccess).isGreaterThan(0);
     }
 }


### PR DESCRIPTION
생성된 기능
- `findAuthorIdById()` : tradePost의 author 정보를 가져올 경우 외래키를 가져오는 method 생성
- `tradePostCreate.sql` : `salesStatus` 에서 `NotNull`과 default가 같이 쓰여 `NotNull`을 지웠습니다. (salesStatus는 null값이 주입될 경우가 없습니다)

`alter table TradePost modify salesStatus int default 0 null;` 쿼리 날리고 쓰시면 됩니다

- `TradePostMapperXml` 에서 `alias`를 사용할 수 있도록 `config.xml`에 추가 설정코드 작성
- `TradePostMapperTest` 작성
- `TradePost`를 `insert`하는 `insertTestTradePost()` 를 `JdbcTemplateHelper`에 작성

- 테스트 코드 통과
<img width="408" alt="스크린샷 2022-01-19 오전 12 11 53" src="https://user-images.githubusercontent.com/58963724/149964033-e8af039e-0750-41f3-b0e4-043a180c239c.png">

- `Comment` 관련 테스트에 mapping 문제로 케이스 3개정도 에러가 납니다. 이 부분은 다음 `CommentMapperTest` PR에서 작성하도록 하겠습니다.