### PR TITLE
TradePostMapper 2

### DIFF
--- a/api/src/main/java/com/hcs/mapper/TradePostMapper.java
+++ b/api/src/main/java/com/hcs/mapper/TradePostMapper.java
@@ -12,9 +12,13 @@ public interface TradePostMapper {
 
     Long findAuthorIdById(long tradePostId);
 
+    int countByTitle(String title);
+
     long insertTradePost(TradePost tradePost);
 
-    int deleteTradePostById(long tradePostId);
+    int updateTradePost(TradePost tradePost);
 
-    // TODO 글쓴이의 이름 가져오기
+    int updateTradePostForView(long tradePostId);
+
+    int deleteTradePostById(long tradePostId);
 }

--- a/api/src/main/resources/mybatis-mapper/TradePostMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/TradePostMapperXml.xml
@@ -21,6 +21,12 @@
         where id = #{id}
     </select>
 
+    <select id="countByTitle" parameterType="String" resultType="int">
+        select COUNT(*)
+        from TradePost
+        where title = #{title}
+    </select>
+
     <insert id="insertTradePost" useGeneratedKeys="true" keyProperty="id" parameterType="TradePost">
         insert into TradePost (authorId, title, productStatus, category, description,
         pictures, locationName, lat, lng, price, salesStatus, registerationTime)
@@ -30,6 +36,26 @@
             SELECT LAST_INSERT_ID()
         </selectKey>
     </insert>
+
+    <update id="updateTradePost" parameterType="TradePost">
+        update TradePost
+        set title         = #{title},
+            category      = #{category},
+            productStatus = #{productStatus},
+            description   = #{description},
+            pictures      = #{pictures},
+            locationName  = #{locationName},
+            lng           = #{lng},
+            lat           = #{lat},
+            price         = #{price}
+        where id = #{id}
+    </update>
+
+    <update id="updateTradePostForView" parameterType="TradePost">
+        update TradePost
+        set views = views + 1
+        where id = #{id}
+    </update>
 
     <delete id="deleteTradePostById" parameterType="long">
         delete

--- a/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
@@ -125,6 +125,33 @@ class TradePostMapperTest {
         assertThat(returnedBy2).isEmpty();
     }
 
+    @DisplayName("TradePostMapper - 제목으로 TradePost 수 찾기")
+    @Test
+    void countByTitleTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+        jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+        jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        int count = tradePostMapper.countByTitle(title);
+
+        assertThat(count).isEqualTo(3);
+    }
+
     @DisplayName("TradePostMapper - TradePost 삽입하기")
     @Test
     void insertTradePostTest() {
@@ -170,6 +197,82 @@ class TradePostMapperTest {
         assertThat(returnedBy.get().getCategory()).isEqualTo(category);
         assertThat(returnedBy.get().getDescription()).isEqualTo(description);
         assertThat(returnedBy.get().getPrice()).isEqualTo(price);
+    }
+
+    @DisplayName("TradePostMapper - TradePost 수정하기")
+    @Test
+    void updateTradePostTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        User author = userMapper.findById(authorId);
+        author.setId(authorId);
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        TradePost modified = TradePost.builder()
+                .id(tradePostId)
+                .title(title)
+                .productStatus(productStatus)
+                .category(category)
+                .description(description + 1)
+                .price(price + 1)
+                .salesStatus(Boolean.parseBoolean(String.valueOf(salesStatus)))
+                .registerationTime(LocalDateTime.now())
+                .author(author)
+                .build();
+
+        int isSuccess = tradePostMapper.updateTradePost(modified);
+
+        assertThat(isSuccess).isGreaterThan(0);
+        assertThat(modified.getId()).isEqualTo(tradePostId);
+        assertThat(modified.getDescription()).isEqualTo(description + 1);
+        assertThat(modified.getPrice()).isEqualTo(price + 1);
+    }
+
+    @DisplayName("TradePostMapper - TradePost 클릭시 조회수 올리기")
+    @Test
+    void updateTradePostForViewTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        User author = userMapper.findById(authorId);
+        author.setId(authorId);
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        TradePost tradePost = tradePostMapper.findById(tradePostId);
+
+        int isSuccess = tradePostMapper.updateTradePostForView(tradePostId);
+
+        TradePost clickedTradePost = tradePostMapper.findById(tradePostId);
+
+        assertThat(isSuccess).isGreaterThan(0);
+        assertThat(clickedTradePost.getViews()).isEqualTo(tradePost.getViews() + 1);
     }
 
     @DisplayName("TradePostMapper - Id로 TradePost 삭제하기")


### PR DESCRIPTION
`TradePostMapper` 기능을 추가하였고 테스트 코드를 작성하였습니다.

- `countByTitle()` : `TradePost`를 수정할 때 같은 제목의 글로 수정할경우 검증단계에서 체크하는데 쓸 용도로 만들었습니다.
- `updateTradePost()` : `TradePost`를 수정할 때 내용을 업데이트 하는 mapper입니다.
- `updateTradePostForView()` :  `User`가 `TradePost`를 클릭할 경우 조회수를 올리기 위한 mapper입니다.

- 모든 테스트를 통과하였습니다.
<img width="422" alt="스크린샷 2022-01-20 오후 9 34 03" src="https://user-images.githubusercontent.com/58963724/150339555-2a5f1953-238d-4c02-ae37-680782e9c319.png">