### PR TITLE
CommentMapper

### DIFF
--- a/api/src/main/java/com/hcs/mapper/CommentMapper.java
+++ b/api/src/main/java/com/hcs/mapper/CommentMapper.java
@@ -12,9 +12,13 @@ public interface CommentMapper {
 
     List<Comment> findByTradePostId(long tradePostId);
 
+    List<Comment> findReplysByParentCommentId(long parentCommentId);
+
     long insertComment(Comment comment);
 
-    int deleteComment(long id);
+    long insertReply(Comment comment);
 
-    // TODO 댓글 수정 추가
+    int updateComment(Comment comment);
+
+    int deleteComment(long id);
 }

--- a/api/src/main/resources/mybatis-config/config.xml
+++ b/api/src/main/resources/mybatis-config/config.xml
@@ -7,5 +7,6 @@
         <typeAlias alias="User" type="com.hcs.domain.User"/>
         <typeAlias alias="UserForJPA" type="com.hcs.domain.UserForJPA"/>
         <typeAlias alias="TradePost" type="com.hcs.domain.TradePost"/>
+        <typeAlias alias="Comment" type="com.hcs.domain.Comment"/>
     </typeAliases>
 </configuration>

--- a/api/src/main/resources/mybatis-mapper/CommentMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/CommentMapperXml.xml
@@ -3,20 +3,26 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.hcs.mapper.CommentMapper">
-
-    <select id="findByTradePostId" parameterType="long" resultType="com.hcs.domain.Comment">
-        select *
-        from Comment
-        where tradePostId = #{tradePostId}
-    </select>
-
-    <select id="findById" parameterType="long" resultType="com.hcs.domain.Comment">
+    <select id="findById" parameterType="long" resultType="Comment">
         select *
         from Comment
         where id = #{id}
     </select>
 
-    <insert id="insertComment" useGeneratedKeys="true" keyProperty="id" parameterType="com.hcs.domain.Comment">
+    <select id="findByTradePostId" parameterType="long" resultType="Comment">
+        select *
+        from Comment
+        where tradePostId = #{tradePostId}
+          AND ISNULL(parentCommentId)
+    </select>
+
+    <select id="findReplysByParentCommentId" parameterType="long" resultType="Comment">
+        select *
+        from Comment
+        where parentCommentId = #{parentCommentId}
+    </select>
+
+    <insert id="insertComment" useGeneratedKeys="true" keyProperty="id" parameterType="Comment">
         insert into Comment (authorId, contents, tradePostId, registerationTime)
         values (#{author.id}, #{contents}, #{tradePost.id}, #{registerationTime})
         <selectKey keyProperty="id" resultType="long" order="AFTER">
@@ -24,10 +30,24 @@
         </selectKey>
     </insert>
 
+    <insert id="insertReply" useGeneratedKeys="true" keyProperty="id" parameterType="Comment">
+        insert into Comment (parentCommentId, authorId, contents, tradePostId, registerationTime)
+        values (#{parentCommentId}, #{author.id}, #{contents}, #{tradePost.id}, #{registerationTime})
+        <selectKey keyProperty="id" resultType="long" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
+    </insert>
+
+    <update id="updateComment" parameterType="Comment">
+        update Comment
+        set contents          = #{contents},
+            registerationTime = #{registerationTime}
+        where id = #{id}
+    </update>
+
     <delete id="deleteComment" parameterType="long">
         delete
         from Comment
         where id = #{id}
     </delete>
-
 </mapper>

--- a/api/src/test/java/com/hcs/common/JdbcTemplateHelper.java
+++ b/api/src/test/java/com/hcs/common/JdbcTemplateHelper.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
+import java.sql.Types;
 import java.time.LocalDateTime;
 
 @Component
@@ -51,6 +52,30 @@ public class JdbcTemplateHelper {
             ps.setString(6, String.valueOf(price));
             ps.setString(7, String.valueOf(salesStatus));
             ps.setString(8, String.valueOf(registerationTime));
+
+            return ps;
+        }, keyHolder);
+
+        return keyHolder.getKey().longValue();
+    }
+
+    public long insertTestComment(long parentCommentId, long authorId, long tradePostId, String contents) {
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        String insertSql = "insert into Comment (parentCommentId, authorId, tradePostId, contents)\n" +
+                "values (?, ?, ?, ?)";
+
+        jdbcTemplate.update(con -> {
+            PreparedStatement ps = con.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS);
+
+            if (parentCommentId == 0) ps.setNull(1, Types.INTEGER);
+            else ps.setLong(1, parentCommentId);
+
+            ps.setLong(2, authorId);
+            ps.setLong(3, tradePostId);
+            ps.setString(4, contents);
+
             return ps;
         }, keyHolder);
 


### PR DESCRIPTION
`CommentMapper` 기능 및 그에 따른 테스트 코드를 작성하였습니다.

- `findByTradePostId()` : `TradePost`에 달린 댓글들을 가져옵니다 (대댓글은 제외)
- `findReplysByParentCommentId()` : 부모 Comment Id값을 받아 자식 Comment를 가져옵니다
- `insertReply()` : 대댓글을 삽입합니다
- `updateComment()`: 댓글의 내용을 수정합니다
- `TradePost`에 달린 댓글의 `parentCommentId`값은 `null` 입니다.

테스트
- `findByTradePostId()` :  `TradePost`에 달린 댓글만 가져오므로 `tradePostId`값 조건 및 `parentCommentId`가 `null`인 `Comment`들을 가져옵니다.
- `findReplysByParentCommentId()` : `parentCommentId` 값을 `where`절에 태워 조건검색합니다. 

<img width="501" alt="스크린샷 2022-01-20 오후 9 47 36" src="https://user-images.githubusercontent.com/58963724/150341918-8182ec2c-127d-4dcb-9a6b-92100495d26a.png">