### PR TITLE
TradePostList using JpaRepository for paging

### DIFF
--- a/api/src/main/java/com/hcs/domain/Comment.java
+++ b/api/src/main/java/com/hcs/domain/Comment.java
@@ -1,5 +1,6 @@
 package com.hcs.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -31,10 +33,7 @@ public class Comment {
     @Column(name = "id")
     private long id;
 
-    @Column(name = "parentCommentId")
-    private long parentCommentId;
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "authorId")
     private User author;
 
@@ -43,10 +42,15 @@ public class Comment {
 
     @ManyToOne
     @JoinColumn(name = "tradePostId")
+    @JsonIgnore
     private TradePost tradePost;
 
-    @OneToMany
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parentCommentId")
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", fetch = FetchType.LAZY)
+    @JsonIgnore
     private Set<Comment> replys = new HashSet<>();
 
     @Column(name = "registerationTime")

--- a/api/src/main/java/com/hcs/domain/TradePost.java
+++ b/api/src/main/java/com/hcs/domain/TradePost.java
@@ -8,15 +8,19 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
+
+@NamedEntityGraph(name = "TradePost.withAuthor", attributeNodes = {
+        @NamedAttributeNode(value = "author")}
+)
 
 @Data
 @Entity
@@ -35,7 +39,7 @@ public class TradePost {
     @Column(name = "title")
     private String title;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "authorId")
     private User author;
 
@@ -56,19 +60,16 @@ public class TradePost {
     private String locationName;
 
     @Column(name = "lng")
-    private double lng;
+    private Double lng;
 
     @Column(name = "lat")
-    private double lat;
+    private Double lat;
 
     @Column(name = "price")
     private Integer price;
 
     @Column(name = "views")
     private Integer views;
-
-    @OneToMany(mappedBy = "tradePost")
-    private Set<Comment> comments = new HashSet<>();
 
     @Column(name = "salesStatus")
     private Boolean salesStatus;

--- a/api/src/main/java/com/hcs/domain/User.java
+++ b/api/src/main/java/com/hcs/domain/User.java
@@ -9,12 +9,8 @@ import lombok.NoArgsConstructor;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
-
 
 /**
  * @Data : @Getter, @Setter, @ToString, @EqualsAndHashCode, @RequireArgsConstructor 등의 기능을 제공
@@ -44,7 +40,7 @@ public class User {
     private String password;
 
     @Column(name = "emailVerified")
-    private boolean emailVerified;
+    private Boolean emailVerified;
 
     @Column(name = "emailCheckToken")
     private String emailCheckToken;
@@ -63,7 +59,4 @@ public class User {
 
     @Column(name = "location")
     private String location;
-
-    @OneToMany(mappedBy = "author")
-    private Set<TradePost> tradePostList = new HashSet<>();
 }

--- a/api/src/main/java/com/hcs/domain/UserForJPA.java
+++ b/api/src/main/java/com/hcs/domain/UserForJPA.java
@@ -9,8 +9,10 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 @Entity
+@Table(name = "user_forjpa")
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/api/src/main/java/com/hcs/repository/TradePostRepository.java
+++ b/api/src/main/java/com/hcs/repository/TradePostRepository.java
@@ -1,0 +1,15 @@
+package com.hcs.repository;
+
+import com.hcs.domain.TradePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+public interface TradePostRepository extends JpaRepository<TradePost, Long> {
+
+    @EntityGraph(value = "TradePost.withAuthor", type = EntityGraph.EntityGraphType.LOAD)
+    Page<TradePost> findListByCategoryAndSalesStatus(String category, boolean salesStatus, Pageable pageable);
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -25,11 +25,12 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        implicit_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
-        physical_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
         hbm2ddl.auto: none
     open-in-view: false
     show-sql: true
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
   redis:
     host: localhost
     port: 6379


### PR DESCRIPTION
`TradePost`의 페이징 기능을 `Jpa`의 `Page` 기능으로 구현하였습니다. 
(주력으로 사용하고있는 `Mybatis` 로 가져오는 것보다 성능상의 이점이 있다 판단하여 작성하였습니다.)

- `hibernate`의 name-strategy를 `camelCase` 로 바꾸어 설정하였습니다.  
(해당 설정으로 `hibernate`는 현재 만들어진 테이블 이름을 인식 할 수 있습니다.)
- `Domain` 객체의 연관관계를 정의하였으며 `@OneToMany` 관계의 객체들을 모두 가져오는 방식이 아닌 단일 쿼리를 여러번 날려 controller단에서 dto 객체에 매핑하여 serving 할 계획입니다.
이를 위해 `@OneToMany` 객체들을 필드에서 지웠습니다.

- N+1 문제를 해결하기 위해 `LAZY` 방식으로 fetchType을 설정하였습니다.
- 리스트를 내려주는 조건은 `salesStatus`와 `category`입니다. 
- 페이지 넘버를 받으면 10개씩 내려주도록 상수를 정의해두었습니다.
- 해당 메소드는 테스트 과정을 거쳤으나 PR의 성격에 맞지 않아 바로 후속 PR을 올리도록 로컬에서 작업이 되어있음을 알려드립니다.