### PR TITLE
update 관련 request시 http method 를 put 으로 변경

### DIFF
--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -68,7 +69,7 @@ public class ClubController {
         return HcsResponse.of(hcsList.club(clubInListDtos, page, count, allClubCounts));
     }
 
-    @PostMapping("/modify")
+    @PutMapping("/modify")
     public HcsResponse modifyClub(@RequestBody ClubSubmitDto clubDto, @RequestParam("clubId") long clubId) {
         clubId = clubService.modifyClub(clubId, clubDto);
         String clubUrl = clubService.makeClubUrl(clubId);

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -215,7 +216,7 @@ class ClubControllerTest {
         clubSubmitDto.setLocation(changedLocation);
         clubSubmitDto.setTitle(changedTitle);
 
-        mockMvc.perform(post("/club/modify")
+        mockMvc.perform(put("/club/modify")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("clubId", String.valueOf(clubId))
                         .content(objectMapper.writeValueAsString(clubSubmitDto))


### PR DESCRIPTION
`update`, `delete` 관련 요청시 HTTP method 를 `POST` 로 사용하던것을 `PUT` , `DELETE` 로 각각 변경하였습니다. (notion 문서에도 반영하였습니다. 혹시 원래대로 변경이 필요한경우 알려주시면 되돌려 놓겠습니다)

관련 내용은 notion 문서에서도 보실 수 있습니다. (동네커뮤니티/Docs/http method 수정하기)
![image](https://user-images.githubusercontent.com/29278980/150406659-33b4f951-732c-4d54-a625-2c2a862a5f76.png)
