### PR TITLE
Exception - IllegalArgumentException 작성

### DIFF
--- a/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
+++ b/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
@@ -81,5 +81,14 @@ public class ExceptionAdvisor {
         return HcsResponse.of(hcsException.exception(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage())));
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public HcsResponse illegalArgumentExceptionHandler(IllegalArgumentException e) {
+
+        ErrorCode error = ErrorCode.ILLEGAL_ARGUMENT;
+
+        return HcsResponse.of(hcsException.exceptionAndLocation(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage()),e.getMessage()));
+    }
+
     // TODO 추후 Response가 만들어지면 공통으로 처리될 error에 대한 전역적인 @ExceptionHandler 추가 작성될 것임.
 }

--- a/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
+++ b/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
@@ -56,7 +56,7 @@ public class ExceptionAdvisor {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(ClubAccessDeniedException.class)
-    public HcsResponse clubAccessDeniedHandler() {
+    public HcsResponse ClubAccessDeniedHandler() {
 
         ErrorCode error = ErrorCode.CLUB_ACCESS_DENIED;
 
@@ -65,7 +65,7 @@ public class ExceptionAdvisor {
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(DatabaseException.class)
-    public HcsResponse databaseExceptionHandler(DatabaseException e) {
+    public HcsResponse DatabaseExceptionHandler(DatabaseException e) {
 
         ErrorCode error = ErrorCode.DATABASE_ERROR;
 
@@ -74,7 +74,7 @@ public class ExceptionAdvisor {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(AlreadyJoinedClubException.class)
-    public HcsResponse alreadyJoinedExceptionHandler() {
+    public HcsResponse AlreadyJoinedExceptionHandler() {
 
         ErrorCode error = ErrorCode.ALREADY_JOINED_CLUB;
 
@@ -83,7 +83,7 @@ public class ExceptionAdvisor {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException.class)
-    public HcsResponse illegalArgumentExceptionHandler(IllegalArgumentException e) {
+    public HcsResponse IllegalArgumentExceptionHandler(IllegalArgumentException e) {
 
         ErrorCode error = ErrorCode.ILLEGAL_ARGUMENT;
 

--- a/api/src/main/java/com/hcs/controller/test/TestExceptionAdvisorController.java
+++ b/api/src/main/java/com/hcs/controller/test/TestExceptionAdvisorController.java
@@ -15,5 +15,10 @@ public class TestExceptionAdvisorController {
     public int NumberFormatException(@PathVariable("id") String testStr) {
         return Integer.parseInt(testStr);
     }
+
+    @GetMapping("/illegalArgu/{id}")
+    public long IllegalArgumentException(@PathVariable("id") long testId) {
+        throw new IllegalArgumentException("test advisor");
+    }
 }
 

--- a/api/src/main/java/com/hcs/exception/ErrorCode.java
+++ b/api/src/main/java/com/hcs/exception/ErrorCode.java
@@ -10,8 +10,9 @@ public enum ErrorCode {
     METHOD_ARGUMENT_NOT_VALID(400, -1, "request body로 전송된 데이터가 검증단계를 통과하지 못함"),
     NUMBER_FORMAT(400, -2, "숫자형으로 요청해주세요"),
     DATABASE_ERROR(500, -3, "db access error"),
+    ILLEGAL_ARGUMENT(400, -4, "잘못된 argument 입니다"),
 
-    CLUB_ACCESS_DENIED(400, -100, "해당 club 의 manager 만 접근이 가능합니다."),
+    CLUB_ACCESS_DENIED(400, -100, "해당 club 의 manager 만 접근이 가능합니다"),
     ALREADY_JOINED_CLUB(400, -101, "이미 club 에 등록한 user 입니다");
 
     private int status;

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -57,7 +57,7 @@ public class ClubService {
 
     private void checkExistingClub(Club club) {
         if (club == null) {
-            throw new IllegalArgumentException(); //TODO : exception 만들어서 교체하기
+            throw new IllegalArgumentException("club");
         }
     }
 

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -305,7 +305,7 @@ class ClubControllerTest {
 
     @DisplayName("없는 club 요청")
     @Test
-    void illegalArgumentException() throws Exception {
+    void IllegalArgumentException() throws Exception {
         mockMvc.perform(get("/club/info")
                         .param("clubId", "-1")
                         .accept(MediaType.APPLICATION_JSON))

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -303,6 +303,20 @@ class ClubControllerTest {
                 .andExpect(jsonPath("$.HCS.status").value(ErrorCode.ALREADY_JOINED_CLUB.getStatus()));
     }
 
+    @DisplayName("없는 club 요청")
+    @Test
+    void illegalArgumentException() throws Exception {
+        mockMvc.perform(get("/club/info")
+                        .param("clubId", "-1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(jsonPath("$.HCS.item.errorCode").value(ErrorCode.ILLEGAL_ARGUMENT.getErrorCode()))
+                .andExpect(jsonPath("$.HCS.item.message").value(ErrorCode.ILLEGAL_ARGUMENT.getMessage()))
+                .andExpect(jsonPath("$.HCS.item.location").value("club"))
+                .andExpect(jsonPath("$.HCS.status").value(ErrorCode.ILLEGAL_ARGUMENT.getStatus()));
+
+    }
+
     private List<Club> generateClubBySizeAndCategoryId(int clubSize, long categoryId) {
         String insertSql = "insert into Club (title, createdAt, categoryId, location) \n" +
                 "values(?,?,?,?)";

--- a/api/src/test/java/com/hcs/controller/ExceptionAdvisorTest.java
+++ b/api/src/test/java/com/hcs/controller/ExceptionAdvisorTest.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -47,5 +48,21 @@ public class ExceptionAdvisorTest {
         assertThat(status).isEqualTo(error.getStatus());
         assertThat(item.get("errorCode")).isEqualTo(error.getErrorCode());
         assertThat(item.get("message")).isEqualTo(error.getMessage());
+    }
+
+    @DisplayName("Exception Handler - IllegalArgumentException - 존재하지 않는 객체를 가리키는 argument 값 사용시")
+    @Test
+    void BAD_REQUEST_IllegalArgumentException() throws Exception {
+        long testId = -1; //불가능한 id
+        ErrorCode code = ErrorCode.ILLEGAL_ARGUMENT;
+        mockMvc.perform(get("/test/illegalArgu/{id}", String.valueOf(testId)))
+                .andDo(print())
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.HCS.status").value(code.getStatus()))
+                .andExpect(jsonPath("$.HCS.item.errorCode").value(code.getErrorCode()))
+                .andExpect(jsonPath("$.HCS.item.message").value(code.getMessage()))
+                .andExpect(jsonPath("$.HCS.item.location").value("test advisor"))
+                .andReturn();
+
     }
 }


### PR DESCRIPTION
reequest param 으로 받은 `clubId`가 없는 club 일경우의 exception 을 작성했습니다.

- 비슷한 다른 객체들이 없는경우에도 사용할 수 있도록 `IllegalArgumentException` 을 사용하고, throw 시 exception 발생 객체 위치를 전달
- exception test작성 및 통과
![image](https://user-images.githubusercontent.com/29278980/150491393-441115fa-1f15-4019-bd26-cb35e671b187.png)
