### PR TITLE
TradePostService 기능 생성 및 테스트 코드

### DIFF
--- a/api/src/main/java/com/hcs/domain/Comment.java
+++ b/api/src/main/java/com/hcs/domain/Comment.java
@@ -33,6 +33,9 @@ public class Comment {
     @Column(name = "id")
     private long id;
 
+    @Column(name = "parentCommentId", insertable = false, updatable = false)
+    private long parentCommentId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "authorId")
     private User author;

--- a/api/src/main/java/com/hcs/dto/request/TradePostDto.java
+++ b/api/src/main/java/com/hcs/dto/request/TradePostDto.java
@@ -1,6 +1,7 @@
 package com.hcs.dto.request;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -12,6 +13,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class TradePostDto {

--- a/api/src/main/java/com/hcs/mapper/TradePostMapper.java
+++ b/api/src/main/java/com/hcs/mapper/TradePostMapper.java
@@ -14,7 +14,7 @@ public interface TradePostMapper {
 
     int countByTitle(String title);
 
-    long insertTradePost(TradePost tradePost);
+    int insertTradePost(TradePost tradePost);
 
     int updateTradePost(TradePost tradePost);
 

--- a/api/src/main/java/com/hcs/repository/TradePostRepository.java
+++ b/api/src/main/java/com/hcs/repository/TradePostRepository.java
@@ -11,5 +11,5 @@ import org.springframework.transaction.annotation.Transactional;
 public interface TradePostRepository extends JpaRepository<TradePost, Long> {
 
     @EntityGraph(value = "TradePost.withAuthor", type = EntityGraph.EntityGraphType.LOAD)
-    Page<TradePost> findListByCategoryAndSalesStatus(String category, boolean salesStatus, Pageable pageable);
+    Page<TradePost> findListsByCategoryAndSalesStatus(String category, boolean salesStatus, Pageable pageable);
 }

--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -1,20 +1,72 @@
 package com.hcs.service;
 
 import com.hcs.domain.TradePost;
+import com.hcs.domain.User;
 import com.hcs.dto.request.TradePostDto;
+import com.hcs.exception.global.DatabaseException;
 import com.hcs.mapper.TradePostMapper;
+import com.hcs.repository.TradePostRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class TradePostService {
 
+    private final ModelMapper modelMapper;
+    private final UserService userService;
     private final TradePostMapper tradePostMapper;
+    private final TradePostRepository tradePostRepository;
 
-    public boolean saveTradePost(TradePostDto tradePostDto) {
-        // TODO 중고게시글 저장하기
-        return true;
+    public TradePost saveTradePost(long authorId, TradePostDto tradePostDto) {
+
+        TradePost tradePost = modelMapper.map(tradePostDto, TradePost.class);
+
+        User author = userService.findById(authorId);
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        tradePost.setAuthor(author);
+        tradePost.setSalesStatus(false);
+        tradePost.setRegisterationTime(registrationTime);
+
+        int isSuccess = tradePostMapper.insertTradePost(tradePost);
+
+        if (isSuccess != 1) {
+            throw new DatabaseException("DB tradePost click");
+        }
+
+        return tradePost;
+    }
+
+    public void clickTradePost(long Id) {
+
+        int isSuccess = tradePostMapper.updateTradePostForView(Id);
+
+        if (isSuccess != 1) {
+            throw new DatabaseException("DB tradePost click");
+        }
+    }
+
+    public long modifyTradePost(long Id, TradePostDto tradePostDto) {
+
+        TradePost tradePost = findById(Id);
+
+        tradePost = modelMapper.map(tradePostDto, TradePost.class);
+        tradePost.setId(Id);
+
+        int isSuccess = tradePostMapper.updateTradePost(tradePost);
+
+        if (isSuccess != 1) {
+            throw new DatabaseException("DB tradePost modify");
+        }
+
+        return tradePost.getId();
     }
 
     public TradePost findByTitle(String title) {
@@ -27,5 +79,20 @@ public class TradePostService {
 
     public Long findAuthorIdById(long Id) {
         return tradePostMapper.findAuthorIdById(Id);
+    }
+
+    public List<TradePost> findTradePostsWithPaging(int page, String category, boolean salesStatus) {
+
+        int pagePerCount = 10;
+
+        PageRequest pageRequest = PageRequest.of(page - 1, pagePerCount, Sort.by("registerationTime").descending());
+
+        List<TradePost> result = tradePostRepository.findListsByCategoryAndSalesStatus(category, salesStatus, pageRequest).getContent();
+
+        return result;
+    }
+
+    public long deleteTradePostById(long Id) {
+        return tradePostMapper.deleteTradePostById(Id);
     }
 }

--- a/api/src/main/resources/sql/userCreate.sql
+++ b/api/src/main/resources/sql/userCreate.sql
@@ -4,7 +4,7 @@ create table User
     email                      VARCHAR(30)  NOT NULL,
     nickname                   VARCHAR(10)  NOT NULL,
     password                   VARCHAR(200) NOT NULL,
-    emailVerified              BOOLEAN,
+    emailVerified              BOOLEAN DEFAULT FALSE,
     emailCheckToken            VARCHAR(50),
     emailCheckTokenGeneratedAt datetime,
     joinedAt                   datetime,

--- a/api/src/test/java/com/hcs/controller/UserControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/UserControllerTest.java
@@ -153,7 +153,7 @@ public class UserControllerTest {
         assertThat(profile.get("userId")).isEqualTo((int) user.getId());
         assertThat(profile.get("email")).isEqualTo(user.getEmail());
         assertThat(profile.get("nickname")).isEqualTo(user.getNickname());
-        assertThat(profile.get("emailVerified")).isEqualTo(user.isEmailVerified());
+        assertThat(profile.get("emailVerified")).isEqualTo(user.getEmailVerified());
         assertThat(profile.get("joinedAt")).isEqualTo(user.getJoinedAt().toString());
         assertThat(profile.get("age")).isEqualTo(user.getAge());
         assertThat(profile.get("position")).isEqualTo(user.getPosition());

--- a/api/src/test/java/com/hcs/service/TradePostServiceTest.java
+++ b/api/src/test/java/com/hcs/service/TradePostServiceTest.java
@@ -1,0 +1,198 @@
+package com.hcs.service;
+
+import com.hcs.common.JdbcTemplateHelper;
+import com.hcs.domain.TradePost;
+import com.hcs.dto.request.TradePostDto;
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EnableEncryptableProperties
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
+@Transactional
+class TradePostServiceTest {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    TradePostService tradePostService;
+
+    @Autowired
+    JdbcTemplateHelper jdbcTemplateHelper;
+
+    @Test
+    @DisplayName("TradePostServiceTest - 중고거래 게시글 저장하기")
+    void saveTradePostTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        String locationName = "seoul station";
+        double lng = 126.97230870958784;
+        double lat = 37.55602954224621;
+
+        TradePostDto tradePostDto = TradePostDto.builder()
+                .title(title)
+                .category(category)
+                .productStatus(productStatus)
+                .description(description)
+                .locationName(locationName)
+                .lng(lng)
+                .lat(lat)
+                .price(price)
+                .build();
+
+        TradePost tradePost = tradePostService.saveTradePost(authorId, tradePostDto);
+
+        assertThat(tradePost).isEqualTo(tradePostService.findById(tradePost.getId()));
+    }
+
+    @Test
+    @DisplayName("TradePostServiceTest - 중고거래 게시글 클릭 시 조회수 올리기")
+    void clickTradePostTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        int click = 5;
+        for (int i = 0; i < click; i++) tradePostService.clickTradePost(tradePostId);
+
+        TradePost tradePost = tradePostService.findById(tradePostId);
+
+        assertThat(tradePost.getViews()).isEqualTo(click);
+    }
+
+    @Test
+    @DisplayName("TradePostServiceTest - 중고거래 게시글 수정하기")
+    void modifyTradePostTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        String title2 = "test2";
+        String productStatus2 = "중2";
+        String category2 = "중2";
+        String description2 = "중2";
+        String locationName = "seoul station";
+        double lng = 126.97230870958784;
+        double lat = 37.55602954224621;
+        int price2 = 20000;
+
+        TradePostDto tradePostDto = TradePostDto.builder()
+                .title(title2)
+                .category(category2)
+                .productStatus(productStatus2)
+                .description(description2)
+                .locationName(locationName)
+                .lng(lng)
+                .lat(lat)
+                .price(price2)
+                .build();
+
+        long tradePostId2 = tradePostService.modifyTradePost(tradePostId, tradePostDto);
+        TradePost tradePost = tradePostService.findById(tradePostId);
+
+        assertThat(tradePost.getId()).isEqualTo(tradePostId2);
+        assertThat(tradePost.getTitle()).isEqualTo(title2);
+        assertThat(tradePost.getCategory()).isEqualTo(category2);
+        assertThat(tradePost.getProductStatus()).isEqualTo(productStatus2);
+        assertThat(tradePost.getDescription()).isEqualTo(description2);
+        assertThat(tradePost.getPrice()).isEqualTo(price2);
+    }
+
+    @Test
+    @DisplayName("TradePostServiceTest - 중고거래 게시글 리스트 정보를 내려주기")
+    void findTradePostsWithPagingTest() {
+
+        int lng = 7;
+
+        String newEmail = "test@naver.com";
+        String newNickname = "tes";
+        String newPassword = "password";
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long authorId = 0;
+        long tradePostId = 0;
+
+        long[] authorIds = new long[lng];
+        long[] tradePostIds = new long[lng];
+
+        for (int i = 0; i < lng; i++) {
+
+            authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+            tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+            authorIds[i] = authorId;
+            tradePostIds[i] = tradePostId;
+
+            newEmail += i;
+            newNickname += i;
+            newPassword += i;
+
+            title += i;
+            productStatus += i;
+            description += i;
+            price += i;
+            registrationTime = LocalDateTime.now();
+        }
+
+        List<TradePost> result = tradePostService.findTradePostsWithPaging(1, category, false);
+
+        for (int i = 0; i < lng; i++) {
+            assertThat(result.get(i)).isEqualTo(tradePostService.findById(tradePostIds[i]));
+            assertThat(result.get(i).getAuthor()).isEqualTo(userService.findById(authorIds[i]));
+        }
+    }
+}


### PR DESCRIPTION
- TradePost의 리스트를 JpaRepository의 Paging API 를 사용하였으며, author(user)도 담아 리턴하였습니다.
- `@NamedEntityGraph` 를 사용하여 쿼리가 추가로 하나만 나가도록 하였습니다.
- 한 페이지당 최대 10개의 `TradePost`를 최신순으로 리턴합니다.
- `db access` 예외처리를 해주었습니다.
- 테스트에 author로 쓰기위해 생성하는 user는  emailVerified를 따로 값을 주어 생성하기 보다 default값을 0 으로 주어 생성되도록 하기위해 column의 default를 추가하였습니다.
(`alter table User alter column emailVerified set default 0;` DB 명령 입력해주세요)

- 모든 테스트 코드를 통과하였습니다.
<img width="504" alt="스크린샷 2022-01-21 오후 5 09 37" src="https://user-images.githubusercontent.com/58963724/150493221-4cdaff36-6766-459b-93a3-475bd4dd76b8.png">