### PR TITLE
TradePostController 기능 생성 및 테스트 코드

### DIFF
--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hcs.domain.Club;
+import com.hcs.domain.TradePost;
 import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInListDto;
-import com.hcs.dto.response.user.UserInfoDto;
 import com.hcs.dto.response.club.ClubInfoDto;
+import com.hcs.dto.response.tradePost.TradePostInfoDto;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
@@ -35,6 +37,10 @@ public class AppConfig {
 
         modelMapper.typeMap(Club.class, ClubInfoDto.class).addMappings(mapping -> {
             mapping.map(Club::getId, ClubInfoDto::setClubId);
+        });
+
+        modelMapper.typeMap(TradePost.class, TradePostInfoDto.class).addMappings(mapping -> {
+            mapping.map(TradePost::getId, TradePostInfoDto::setTradePostId);
         });
 
         return modelMapper;

--- a/api/src/main/java/com/hcs/controller/TradePostController.java
+++ b/api/src/main/java/com/hcs/controller/TradePostController.java
@@ -1,36 +1,126 @@
 package com.hcs.controller;
 
+import com.hcs.domain.TradePost;
+import com.hcs.domain.User;
+import com.hcs.dto.request.TradePostDto;
 import com.hcs.dto.response.HcsResponse;
+import com.hcs.dto.response.method.HcsDelete;
+import com.hcs.dto.response.method.HcsInfo;
+import com.hcs.dto.response.method.HcsList;
+import com.hcs.dto.response.method.HcsModify;
+import com.hcs.dto.response.method.HcsSubmit;
+import com.hcs.dto.response.tradePost.TradePostInfoDto;
+import com.hcs.dto.response.tradePost.TradePostListDto;
+import com.hcs.dto.response.user.UserInfoDto;
 import com.hcs.service.TradePostService;
+import com.hcs.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.MapBindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("/post/tradePost")
 @RequiredArgsConstructor
 public class TradePostController {
 
+    private final ModelMapper modelMapper;
+    private final UserService userService;
     private final TradePostService tradePostService;
+    private final HcsInfo info;
+    private final HcsList list;
+    private final HcsSubmit submit;
+    private final HcsModify modify;
+    private final HcsDelete delete;
+
+    @GetMapping("/info")
+    public HcsResponse tradePost(@RequestParam("tradePostId") long tradePostId) {
+
+        long authorId = tradePostService.findAuthorIdById(tradePostId);
+
+        TradePost tradePost = tradePostService.findById(tradePostId);
+        User author = userService.findById(authorId);
+
+        TradePostInfoDto tradePostInfoDto = modelMapper.map(tradePost, TradePostInfoDto.class);
+        UserInfoDto userInfoDto = modelMapper.map(author, UserInfoDto.class);
+
+        tradePostInfoDto.setAuthor(userInfoDto);
+
+        return HcsResponse.of(info.tradePost(tradePostInfoDto));
+    }
 
     @GetMapping("/list")
     public HcsResponse tradePosts(@RequestParam("page") int page, @RequestParam("category") String category, @RequestParam("salesStatus") boolean salesStatus) {
 
-//        List<TradePost> tradePostList = tradePostService.getTradePostList(page, category, salesStatus);
+        List<TradePost> tradePosts = tradePostService.findTradePostsWithPaging(page, category, salesStatus);
+        List<TradePostInfoDto> tradePostInfoDtos = new ArrayList<>();
 
-        Map<String, Object> tradePostInfo = new HashMap<>();
-        tradePostInfo.put("page", page);
-//        tradePostInfo.put("count", tradePostList.size());
-        tradePostInfo.put("category", category);
-        tradePostInfo.put("salesStatus", salesStatus);
+        for (TradePost tradePost : tradePosts) {
+            TradePostInfoDto info = modelMapper.map(tradePost, TradePostInfoDto.class);
+            tradePostInfoDtos.add(info);
+        }
 
-//        return hcsResponseManager.list.tradePost(tradePostInfo, tradePostList);
-        return null;
+        TradePostListDto tradePostListDto = TradePostListDto.builder()
+                .page(page)
+                .count(tradePosts.size())
+                .salesStatus(salesStatus)
+                .category(category)
+                .tradePosts(tradePostInfoDtos)
+                .build();
+
+        return HcsResponse.of(list.tradePost(tradePostListDto));
     }
 
+    @PostMapping("/submit")
+    public HcsResponse saveTradePost(@Valid @RequestBody TradePostDto tradePostDto, @RequestParam("authorId") long authorId) {
+
+        TradePost newTradePost = tradePostService.saveTradePost(authorId, tradePostDto);
+        long tradePostId = newTradePost.getId();
+
+        return HcsResponse.of(submit.tradePost(authorId, tradePostId));
+    }
+
+    @PutMapping("/modify")
+    public HcsResponse modifyTradePost(@Valid @RequestBody TradePostDto tradePostDto, @RequestParam("tradePostId") long tradePostId) throws MethodArgumentNotValidException {
+
+        modifyTradePostValidation(tradePostId, tradePostDto.getTitle());
+        tradePostService.modifyTradePost(tradePostId, tradePostDto);
+
+        return HcsResponse.of(modify.tradePost(tradePostId));
+    }
+
+    @DeleteMapping("/delete")
+    public HcsResponse deleteTradePost(@RequestParam("tradePostId") long tradePostId) {
+
+        tradePostService.deleteTradePostById(tradePostId);
+
+        return HcsResponse.of(delete.tradePost(tradePostId));
+    }
+
+    private void modifyTradePostValidation(long tradePostId, String title) throws MethodArgumentNotValidException {
+
+        TradePost originTradePost = tradePostService.findById(tradePostId);
+        Errors errors = new MapBindingResult(new HashMap<>(), "a");
+
+        if (originTradePost.getTitle() != title && tradePostService.countByTitle(title) > 0) {
+
+            errors.rejectValue("title", "invalid.title", new Object[]{title}, "이미 사용중인 제목 입니다.");
+            throw new MethodArgumentNotValidException(null, (BindingResult) errors);
+        }
+    }
 }

--- a/api/src/main/java/com/hcs/dto/request/TradePostDto.java
+++ b/api/src/main/java/com/hcs/dto/request/TradePostDto.java
@@ -11,6 +11,7 @@ import javax.persistence.Lob;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Data
 @Builder
@@ -45,7 +46,7 @@ public class TradePostDto {
     @Max(90)
     private double lat;
 
-    @NotBlank
+    @NotNull
     @Range(min = 1_000, max = 1_000_000, message = "1,000원 이상 1,000,000원 이하의 범위까지 가능합니다.")
     private Integer price;
 }

--- a/api/src/main/java/com/hcs/dto/response/method/HcsDelete.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsDelete.java
@@ -34,4 +34,16 @@ public class HcsDelete {
 
         return hcs;
     }
+
+    public ObjectNode tradePost(long tradePostId) {
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.createObjectNode();
+
+        item.put("tradePostId", tradePostId);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+
+        return hcs;
+    }
 }

--- a/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
@@ -3,11 +3,10 @@ package com.hcs.dto.response.method;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.hcs.domain.Club;
-import com.hcs.dto.response.user.UserInfoDto;
-import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.club.ClubUserDto;
+import com.hcs.dto.response.tradePost.TradePostInfoDto;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -70,6 +69,17 @@ public class HcsInfo {
     public ObjectNode club(ClubInfoDto clubInfoDto) {
         ObjectNode hcs = objectMapper.createObjectNode();
         ObjectNode item = clubInfo(clubInfoDto);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+
+        return hcs;
+    }
+
+    public ObjectNode tradePost(TradePostInfoDto tradePostInfoDto) {
+
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.valueToTree(tradePostInfoDto);
 
         hcs.put("status", 200);
         hcs.set("item", item);

--- a/api/src/main/java/com/hcs/dto/response/method/HcsList.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsList.java
@@ -3,14 +3,13 @@ package com.hcs.dto.response.method;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.hcs.domain.TradePost;
 import com.hcs.dto.response.club.ClubInListDto;
+import com.hcs.dto.response.tradePost.TradePostListDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Map;
 
 @Component
 public class HcsList {
@@ -18,28 +17,9 @@ public class HcsList {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private ObjectNode item(Map<String, Object> tradePostInfo, List<TradePost> tradePostList) {
-        ObjectNode item = objectMapper.createObjectNode();
-        ArrayNode tradePosts = objectMapper.createArrayNode();
-
-        item.put("page", (int) tradePostInfo.get("page"));
-        item.put("count", (int) tradePostInfo.get("count"));
-        item.put("salesStatus", (boolean) tradePostInfo.get("salesStatus"));
-        item.put("category", (String) tradePostInfo.get("category"));
-
-        for (TradePost tradePost : tradePostList) {
-            ObjectNode tradePostNode = objectMapper.valueToTree(tradePost);
-            tradePosts.add(tradePostNode);
-        }
-
-        item.set("tradePosts", tradePosts);
-
-        return item;
-    }
-
-    public ObjectNode tradePost(Map<String, Object> tradePostInfo, List<TradePost> tradePostList) {
+    public ObjectNode tradePost(TradePostListDto tradePostListDto) {
         ObjectNode hcs = objectMapper.createObjectNode();
-        ObjectNode item = item(tradePostInfo, tradePostList);
+        ObjectNode item = objectMapper.valueToTree(tradePostListDto);
 
         hcs.put("status", 200);
         hcs.set("item", item);

--- a/api/src/main/java/com/hcs/dto/response/method/HcsModify.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsModify.java
@@ -33,4 +33,15 @@ public class HcsModify {
         hcs.set("item", item);
         return hcs;
     }
+
+    public ObjectNode tradePost(long tradePostId) {
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.createObjectNode();
+
+        item.put("tradePostId", tradePostId);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+        return hcs;
+    }
 }

--- a/api/src/main/java/com/hcs/dto/response/method/HcsSubmit.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsSubmit.java
@@ -38,12 +38,26 @@ public class HcsSubmit {
         return hcs;
     }
 
-    public ObjectNode joinClub(ClubJoinDto dto){
+    public ObjectNode joinClub(ClubJoinDto dto) {
         ObjectNode hcs = objectMapper.createObjectNode();
         ObjectNode item = objectMapper.createObjectNode();
 
         ObjectNode member = objectMapper.valueToTree(dto);
         item.set("member", member);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+
+        return hcs;
+    }
+
+    public ObjectNode tradePost(long authorId, long tradePostId) {
+
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.createObjectNode();
+
+        item.put("authorId", authorId);
+        item.put("tradePostId", tradePostId);
 
         hcs.put("status", 200);
         hcs.set("item", item);

--- a/api/src/main/java/com/hcs/dto/response/tradePost/TradePostInfoDto.java
+++ b/api/src/main/java/com/hcs/dto/response/tradePost/TradePostInfoDto.java
@@ -1,0 +1,31 @@
+package com.hcs.dto.response.tradePost;
+
+import com.hcs.dto.response.user.UserInfoDto;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class TradePostInfoDto {
+
+    private long tradePostId;
+    private String title;
+
+    private UserInfoDto author;
+    private String productStatus;
+    private String category;
+    private String description;
+
+    // TODO : 클래스 파일 생성 및 사진에 대한 비즈니스 로직 작성
+//    private Set<Picture> pictures;
+
+    private String locationName;
+    private double lng;
+    private double lat;
+    private int price;
+    private int views;
+
+    private boolean salesStatus;
+    private LocalDateTime registerationTime;
+}
+

--- a/api/src/main/java/com/hcs/dto/response/tradePost/TradePostListDto.java
+++ b/api/src/main/java/com/hcs/dto/response/tradePost/TradePostListDto.java
@@ -1,0 +1,17 @@
+package com.hcs.dto.response.tradePost;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class TradePostListDto {
+
+    private int page;
+    private int count;
+    private boolean salesStatus;
+    private String category;
+    private List<TradePostInfoDto> tradePosts;
+}

--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -92,6 +92,10 @@ public class TradePostService {
         return result;
     }
 
+    public int countByTitle(String title) {
+        return tradePostMapper.countByTitle(title);
+    }
+
     public long deleteTradePostById(long Id) {
         return tradePostMapper.deleteTradePostById(Id);
     }

--- a/api/src/test/java/com/hcs/controller/TradePostControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/TradePostControllerTest.java
@@ -1,0 +1,479 @@
+package com.hcs.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hcs.annotation.EnableMockMvc;
+import com.hcs.common.JdbcTemplateHelper;
+import com.hcs.domain.TradePost;
+import com.hcs.dto.request.TradePostDto;
+import com.hcs.service.TradePostService;
+import com.hcs.service.UserService;
+import com.jayway.jsonpath.JsonPath;
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import net.minidev.json.JSONArray;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @SpringBootTest : 통합테스트를 목적으로 SpringBoot에서 제공하는 테스트 어노테이션
+ * @EnableMockMvc : MockMvc 한글 깨짐 현상을 해결하기 위해 @AutoConfigureMockMvc에 주입시킬 필터가 추가된 어노테이션.
+ * @EnableEncryptableProperties : application.yml 파일의 내용이 암호화된 경우, 복호화에 필요한 설정을 제공해줌.
+ * @Transactional : 적용된 범위에서 트랜잭션 기능이 포함된 프록시 객체가 생성되어 자동으로 commit or rollback을 진행해준다.
+ * @Test : 테스트를 만드는 모듈 역할을 하는 어노테이션. 테스트 할 메소드를 지정하는데 사용됨.
+ * @ParameterizedTest : 여러 argument로 테스트를 여러번 돌릴 수 있는 어노테이션
+ * @MethodSource : factory method가 리턴해주는 값이 parameter로 쓰이도록 주입해주는 어노테이션
+ */
+
+@SpringBootTest
+@EnableMockMvc
+@EnableEncryptableProperties
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
+@Transactional
+public class TradePostControllerTest {
+
+    private static TradePostDto tradePostDto = new TradePostDto();
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    TradePostService tradePostService;
+
+    @Autowired
+    JdbcTemplateHelper jdbcTemplateHelper;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    static Stream<Arguments> stringListProvider() {
+        return Stream.of(
+                arguments("tes", "", "", "", "loca", "-181", "-91", "999", Arrays.asList("title", "category", "productStatus", "description", "locationName", "lng", "lat", "price")),
+                arguments("tes", "중", "중", "중", "seoul station", "126.97230870958784", "37.55602954224621", "10000", Arrays.asList("title")),
+                arguments("testTitle", "중", "중", "중", "cafe", "126.97230870958784", "37.55602954224621", "10000", Arrays.asList("locationName")),
+                arguments("testTitle", "중", "중", "중", "seoul station", "126.97230870958784", "37.55602954224621", "10000000", Arrays.asList("price"))
+        );
+    }
+
+    static Stream<Arguments> stringListProvider2() {
+        return Stream.of(
+                arguments("testT", "중", "중", "중", "seoul station", "126.97230870958784", "37.55602954224621", "10000", Arrays.asList("title")),
+                arguments("testTitle", "중", "중", "중", "cafe", "126.97230870958784", "37.55602954224621", "10000", Arrays.asList("locationName")),
+                arguments("testTitle", "중", "중", "중", "seoul station", "126.97230870958784", "37.55602954224621", "10000000", Arrays.asList("price"))
+        );
+    }
+
+    @DisplayName("중고거래 정보 요청시 리턴되는 body를 확인")
+    @Test
+    void tradePostInfoTest() throws Exception {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        MvcResult mvcResult = mockMvc.perform(get("/post/tradePost/info")
+                        .param("tradePostId", String.valueOf(tradePostId)))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = mvcResult.getResponse().getContentAsString();
+
+        int status = JsonPath.parse(response).read("$.HCS.status");
+        HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
+
+        assertThat(status).isEqualTo(200);
+
+        assertThat(item.get("tradePostId")).isEqualTo((int) tradePostId);
+        assertThat(item.get("title")).isEqualTo(title);
+
+        LinkedHashMap author = (LinkedHashMap) item.get("author");
+
+        assertThat(author.get("userId")).isEqualTo((int) authorId);
+        assertThat(author.get("email")).isEqualTo(newEmail);
+        assertThat(author.get("nickname")).isEqualTo(newNickname);
+
+        assertThat(item.get("productStatus")).isEqualTo(productStatus);
+        assertThat(item.get("category")).isEqualTo(category);
+        assertThat(item.get("description")).isEqualTo(description);
+        assertThat(item.get("price")).isEqualTo(price);
+    }
+
+    @DisplayName("중고거래 페이지 요청시 리턴되는 body를 확인")
+    @Test
+    void tradePostListTest_with_paging() throws Exception {
+
+        int lng = 3;
+
+        String newEmail = "test@naver.com";
+        String newNickname = "tes";
+        String newPassword = "password";
+
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = null;
+
+        long authorId = 0;
+        long tradePostId = 0;
+
+        long[] authorIds = new long[lng];
+        long[] tradePostIds = new long[lng];
+
+        for (int i = 0; i < lng; i++) {
+
+            newEmail += i;
+            newNickname += i;
+            newPassword += i;
+
+            title += i;
+            productStatus += i;
+            description += i;
+            price += i;
+            registrationTime = LocalDateTime.now();
+
+            authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+            tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+            authorIds[i] = authorId;
+            tradePostIds[i] = tradePostId;
+        }
+
+        int page = 1;
+
+        MvcResult mvcResult = mockMvc.perform(get("/post/tradePost/list")
+                        .param("page", String.valueOf(page))
+                        .param("category", category)
+                        .param("salesStatus", String.valueOf(salesStatus)))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = mvcResult.getResponse().getContentAsString();
+
+        int status = JsonPath.parse(response).read("$.HCS.status");
+        HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
+
+        assertThat(status).isEqualTo(200);
+
+        JSONArray tradePosts = (JSONArray) item.get("tradePosts");
+
+        assertThat(item.get("page")).isEqualTo(page);
+        assertThat(item.get("count")).isEqualTo(tradePosts.size());
+        assertThat(item.get("salesStatus")).isEqualTo(Boolean.valueOf(String.valueOf(salesStatus)));
+        assertThat(item.get("category")).isEqualTo(category);
+
+        title = "test";
+        productStatus = "중";
+        description = "중";
+        price = 10000;
+
+        for (int i = 0; i < tradePosts.size(); i++) {
+            LinkedHashMap tradePost = (LinkedHashMap) tradePosts.get(i);
+
+            assertThat((int) tradePost.get("tradePostId")).isEqualTo(tradePostIds[i]);
+            assertThat(tradePost.get("title")).isEqualTo(title + i);
+
+            LinkedHashMap author = (LinkedHashMap) tradePost.get("author");
+            assertThat((int) author.get("userId")).isEqualTo(authorIds[i]);
+
+            assertThat(tradePost.get("productStatus")).isEqualTo(productStatus + i);
+            assertThat(tradePost.get("description")).isEqualTo(description + i);
+            assertThat(tradePost.get("price")).isEqualTo(price + i);
+
+            title += i;
+            productStatus += i;
+            description += i;
+            price += i;
+        }
+    }
+
+    @DisplayName("중고거래 글 생성 처리 - 입력값 정상")
+    @Test
+    void saveTradePost_with_correct_input() throws Exception {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        String title = "testTitle";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        String locationName = "seoul station";
+        double lng = 126.97230870958784;
+        double lat = 37.55602954224621;
+
+        tradePostDto = TradePostDto.builder()
+                .title(title)
+                .category(category)
+                .productStatus(productStatus)
+                .description(description)
+                .locationName(locationName)
+                .lng(lng)
+                .lat(lat)
+                .price(price)
+                .build();
+
+        MvcResult mvcResult = mockMvc.perform(post("/post/tradePost/submit")
+                        .param("authorId", String.valueOf(authorId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tradePostDto))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = mvcResult.getResponse().getContentAsString();
+
+        int status = JsonPath.parse(response).read("$.HCS.status");
+        HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
+
+        assertThat(status).isEqualTo(200);
+        assertThat(item.get("authorId")).isEqualTo((int) authorId);
+
+        TradePost tradePost = tradePostService.findByTitle(title);
+
+        assertThat(item.get("tradePostId")).isEqualTo(tradePost.getId().intValue());
+    }
+
+    @DisplayName("중고거래 글 생성 처리 - 입력값 오류")
+    @ParameterizedTest(name = "#{index} - {displayName} = Test with Argument={0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}")
+    @MethodSource("stringListProvider")
+    void saveTradePost_with_wrong_input(String title, String productStatus, String category, String description,
+                                        String locationName, double lng, double lat, int price, List<String> invalidFields) throws Exception {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        tradePostDto = TradePostDto.builder()
+                .title(title)
+                .category(category)
+                .productStatus(productStatus)
+                .description(description)
+                .locationName(locationName)
+                .lng(lng)
+                .lat(lat)
+                .price(price)
+                .build();
+
+        MvcResult mvcResult = mockMvc.perform(post("/post/tradePost/submit")
+                        .param("authorId", String.valueOf(authorId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tradePostDto))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+
+        String response = mvcResult.getResponse().getContentAsString();
+
+        int status = JsonPath.parse(response).read("$.HCS.status");
+        int length = JsonPath.parse(response).read("$.HCS.item.errors.length()");
+
+        assertThat(status).isEqualTo(400);
+
+        for (int i = 0; i < length; i++) {
+            String field = JsonPath.parse(response).read("$.HCS.item.errors[" + i + "].field");
+            assertThat(invalidFields).contains(field);
+        }
+    }
+
+    @DisplayName("중고거래 글 수정 처리 - 입력값 정상")
+    @Test
+    void modifyTradePost_with_correct_input() throws Exception {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        String title = "testTitle";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        String locationName = "seoul station";
+        double lng = 126.97230870958784;
+        double lat = 37.55602954224621;
+
+        tradePostDto = TradePostDto.builder()
+                .title(title + 1)
+                .category(category + 1)
+                .productStatus(productStatus + 1)
+                .description(description + 1)
+                .locationName(locationName + 1)
+                .lng(lng)
+                .lat(lat)
+                .price(price + 1)
+                .build();
+
+        MvcResult mvcResult = mockMvc.perform(put("/post/tradePost/modify")
+                        .param("tradePostId", String.valueOf(tradePostId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tradePostDto))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = mvcResult.getResponse().getContentAsString();
+
+        int status = JsonPath.parse(response).read("$.HCS.status");
+        HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
+
+        assertThat(status).isEqualTo(200);
+        assertThat(item.get("tradePostId")).isEqualTo((int) tradePostId);
+    }
+
+    @DisplayName("중고거래 글 수정 처리 - 입력값 오류")
+    @ParameterizedTest(name = "#{index} - {displayName} = Test with Argument={0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}")
+    @MethodSource("stringListProvider2")
+    void modifyTradePost_with_wrong_input(String title, String productStatus, String category, String description,
+                                          String locationName, double lng, double lat, int price, List<String> invalidFields) throws Exception {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        String title_ = "testT";
+        String productStatus_ = "중";
+        String category_ = "중";
+        String description_ = "중";
+        int price_ = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId1 = jdbcTemplateHelper.insertTestTradePost(authorId, title_, productStatus_, category_, description_, price_, salesStatus, registrationTime);
+        long tradePostId2 = jdbcTemplateHelper.insertTestTradePost(authorId, title_ + 1, productStatus_, category_, description_, price_, salesStatus, registrationTime);
+
+        tradePostDto = TradePostDto.builder()
+                .title(title)
+                .category(category)
+                .productStatus(productStatus)
+                .description(description)
+                .locationName(locationName)
+                .lng(lng)
+                .lat(lat)
+                .price(price)
+                .build();
+
+        MvcResult mvcResult = mockMvc.perform(put("/post/tradePost/modify")
+                        .param("tradePostId", String.valueOf(tradePostId2))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tradePostDto))
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andDo(print())
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+
+        String response = mvcResult.getResponse().getContentAsString();
+
+        int status = JsonPath.parse(response).read("$.HCS.status");
+        int length = JsonPath.parse(response).read("$.HCS.item.errors.length()");
+
+        assertThat(status).isEqualTo(400);
+
+        for (int i = 0; i < length; i++) {
+            String field = JsonPath.parse(response).read("$.HCS.item.errors[" + i + "].field");
+            assertThat(invalidFields).contains(field);
+        }
+    }
+
+    @DisplayName("중고거래 글 삭제")
+    @Test
+    void deleteTradePost_with_correct_input() throws Exception {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+
+        String title = "testTitle";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        MvcResult mvcResult = mockMvc.perform(delete("/post/tradePost/delete")
+                        .param("tradePostId", String.valueOf(tradePostId)))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = mvcResult.getResponse().getContentAsString();
+
+        int status = JsonPath.parse(response).read("$.HCS.status");
+        HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
+
+        assertThat(status).isEqualTo(200);
+        assertThat(item.get("tradePostId")).isEqualTo((int) tradePostId);
+    }
+}


### PR DESCRIPTION
`TradePostController` 의 `info`, `list`, `submit`, `modify`, `delete` 기능 및 테스트 코드를 작성하었습니다.

- 응답에 사용되는 `TradePostInfoDto`, `TradPostListDto`를 생성하였습니다.
- 이에 따른 HcsXXX의 메소드를 생성하였습니다

- 모든 테스트 코드를 통과하였습니다.
<img width="483" alt="스크린샷 2022-01-22 오전 1 07 24" src="https://user-images.githubusercontent.com/58963724/150560309-dd40cfeb-ee73-4e87-9c08-99878f7501a6.png">