### PR TITLE
add joinedAt and registerationTime at JdbcTemplateHelper

### DIFF
--- a/api/src/test/java/com/hcs/common/JdbcTemplateHelper.java
+++ b/api/src/test/java/com/hcs/common/JdbcTemplateHelper.java
@@ -17,18 +17,19 @@ public class JdbcTemplateHelper {
     @Autowired
     JdbcTemplate jdbcTemplate;
 
-    public long insertTestUser(String newEmail, String newNickname, String newPassword) {
+    public long insertTestUser(String newEmail, String newNickname, String newPassword, LocalDateTime joinedAt) {
 
         KeyHolder keyHolder = new GeneratedKeyHolder();
 
-        String insertSql = "insert into User (email, nickname, password)\n" +
-                "values (?, ?, ?)";
+        String insertSql = "insert into User (email, nickname, password, joinedAt)\n" +
+                "values (?, ?, ?, ?)";
 
         jdbcTemplate.update(con -> {
             PreparedStatement ps = con.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS);
             ps.setString(1, newEmail);
             ps.setString(2, newNickname);
             ps.setString(3, newPassword);
+            ps.setString(4, String.valueOf(joinedAt));
             return ps;
         }, keyHolder);
 
@@ -59,12 +60,12 @@ public class JdbcTemplateHelper {
         return keyHolder.getKey().longValue();
     }
 
-    public long insertTestComment(long parentCommentId, long authorId, long tradePostId, String contents) {
+    public long insertTestComment(long parentCommentId, long authorId, long tradePostId, String contents, LocalDateTime registerationTime) {
 
         KeyHolder keyHolder = new GeneratedKeyHolder();
 
-        String insertSql = "insert into Comment (parentCommentId, authorId, tradePostId, contents)\n" +
-                "values (?, ?, ?, ?)";
+        String insertSql = "insert into Comment (parentCommentId, authorId, tradePostId, contents, registerationTime)\n" +
+                "values (?, ?, ?, ?, ?)";
 
         jdbcTemplate.update(con -> {
             PreparedStatement ps = con.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS);
@@ -75,6 +76,7 @@ public class JdbcTemplateHelper {
             ps.setLong(2, authorId);
             ps.setLong(3, tradePostId);
             ps.setString(4, contents);
+            ps.setString(5, String.valueOf(registerationTime));
 
             return ps;
         }, keyHolder);

--- a/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @AutoConfigureTestDatabase : 테스트시에 사용될 DB를 별도로 할지 선택할 수 있음
  * @MybatisTest : mybatis의 unit test를 할 경우 사용됨. unit test에 사용될 Bean들만 filtering할 수 있음
- * * @DataJpaTest : JPA 관련 테스트 설정만 로드하며 슬라이싱 테스트 시에 사용되는 어노테이션
+ * @DataJpaTest : JPA 관련 테스트 설정만 로드하며 슬라이싱 테스트 시에 사용되는 어노테이션
  */
 
 @EnableEncryptableProperties
@@ -49,9 +49,9 @@ class CommentMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -63,8 +63,9 @@ class CommentMapperTest {
         long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
 
         String contents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
 
-        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents);
+        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents, comment_registerationTime);
 
         Comment comment = commentMapper.findById(commentId);
 
@@ -78,9 +79,9 @@ class CommentMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -94,9 +95,10 @@ class CommentMapperTest {
         int lng = 5;
 
         String contents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
 
         for (int i = 0; i < lng; i++) {
-            jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents + i);
+            jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents + i, comment_registerationTime.plusSeconds(i));
         }
 
         ArrayList<Comment> comments = (ArrayList<Comment>) commentMapper.findByTradePostId(tradePostId);
@@ -117,9 +119,9 @@ class CommentMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -131,15 +133,16 @@ class CommentMapperTest {
         long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
 
         String parentContents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
 
-        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, parentContents);
+        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, parentContents, comment_registerationTime);
 
         int lng = 5;
 
         String contents = "test 댓글내용";
 
         for (int i = 0; i < lng; i++) {
-            jdbcTemplateHelper.insertTestComment(commentId, authorId, tradePostId, contents + i);
+            jdbcTemplateHelper.insertTestComment(commentId, authorId, tradePostId, contents + i, comment_registerationTime.plusSeconds(i + 1));
         }
 
         ArrayList<Comment> comments = (ArrayList<Comment>) commentMapper.findReplysByParentCommentId(commentId);
@@ -160,9 +163,9 @@ class CommentMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -192,9 +195,9 @@ class CommentMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -206,8 +209,9 @@ class CommentMapperTest {
         long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
 
         String contents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
 
-        long parentCommentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents);
+        long parentCommentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents, comment_registerationTime);
 
         String replyContents = "test 댓글내용_reply";
 
@@ -229,9 +233,9 @@ class CommentMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -243,8 +247,9 @@ class CommentMapperTest {
         long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
 
         String contents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
 
-        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents);
+        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents, comment_registerationTime);
 
         Comment comment = commentMapper.findById(commentId);
 
@@ -263,12 +268,26 @@ class CommentMapperTest {
     @Test
     void deleteCommentTest() {
 
-        long authorId = 31L;
-        long tradePostId = 8L;
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
 
         String contents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
 
-        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents);
+        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents, comment_registerationTime);
 
         int result = commentMapper.deleteComment(commentId);
 

--- a/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/TradePostMapperTest.java
@@ -38,8 +38,9 @@ class TradePostMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -68,8 +69,9 @@ class TradePostMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -98,8 +100,9 @@ class TradePostMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -132,9 +135,9 @@ class TradePostMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -159,8 +162,9 @@ class TradePostMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
 
         User author = userMapper.findById(authorId);
         author.setId(authorId);
@@ -206,8 +210,9 @@ class TradePostMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
 
         User author = userMapper.findById(authorId);
         author.setId(authorId);
@@ -249,8 +254,9 @@ class TradePostMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
 
         User author = userMapper.findById(authorId);
         author.setId(authorId);
@@ -282,8 +288,9 @@ class TradePostMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";

--- a/api/src/test/java/com/hcs/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/UserMapperTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,8 +34,9 @@ class UserMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
 
         Optional<User> returnedBy = Optional.ofNullable(userMapper.findById(userId));
 
@@ -51,8 +53,9 @@ class UserMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
 
         Optional<User> returnedBy = Optional.ofNullable(userMapper.findByEmail(newEmail));
 
@@ -69,8 +72,9 @@ class UserMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
 
         Optional<User> returnedBy = Optional.ofNullable(userMapper.findByNickname(newNickname));
 
@@ -87,10 +91,11 @@ class UserMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-        jdbcTemplateHelper.insertTestUser(newEmail, newNickname + 1, newPassword + 1);
-        jdbcTemplateHelper.insertTestUser(newEmail, newNickname + 2, newPassword + 2);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword + 1, joinedAt.plusSeconds(1));
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword + 2, joinedAt.plusSeconds(2));
 
         int count = userMapper.countByEmail(newEmail);
 
@@ -104,10 +109,11 @@ class UserMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-        jdbcTemplateHelper.insertTestUser(newEmail + 1, newNickname, newPassword + 1);
-        jdbcTemplateHelper.insertTestUser(newEmail + 2, newNickname, newPassword + 2);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword + 1, joinedAt.plusSeconds(1));
+        jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword + 2, joinedAt.plusSeconds(2));
 
         int count = userMapper.countByNickname(newNickname);
 
@@ -140,8 +146,9 @@ class UserMapperTest {
         String newEmail = "test2@naver.com";
         String newNickname = "test2";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
 
         int age = 20;
         String position = "backend";
@@ -169,8 +176,9 @@ class UserMapperTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
+        long userId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         long isSuccess = userMapper.deleteUserById(userId);
 
         assertThat(isSuccess).isGreaterThan(0);

--- a/api/src/test/java/com/hcs/service/CommentServiceTest.java
+++ b/api/src/test/java/com/hcs/service/CommentServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @EnableEncryptableProperties
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 class CommentServiceTest {
 
@@ -47,9 +49,9 @@ class CommentServiceTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -83,9 +85,9 @@ class CommentServiceTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -97,8 +99,9 @@ class CommentServiceTest {
         long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
 
         String contents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
 
-        long parentCommentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents);
+        long parentCommentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents, comment_registerationTime);
 
         String replyContents = "test 댓글내용_reply";
 
@@ -123,9 +126,9 @@ class CommentServiceTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -137,8 +140,9 @@ class CommentServiceTest {
         long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
 
         String contents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
 
-        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents);
+        long commentId = jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents, comment_registerationTime);
 
         String modifiedContents = "modified_" + contents;
 

--- a/api/src/test/java/com/hcs/service/TradePostServiceTest.java
+++ b/api/src/test/java/com/hcs/service/TradePostServiceTest.java
@@ -38,9 +38,9 @@ class TradePostServiceTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -73,9 +73,9 @@ class TradePostServiceTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -101,9 +101,9 @@ class TradePostServiceTest {
         String newEmail = "test@naver.com";
         String newNickname = "test";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
-        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
         String title = "test";
         String productStatus = "중";
         String category = "중";
@@ -154,6 +154,7 @@ class TradePostServiceTest {
         String newEmail = "test@naver.com";
         String newNickname = "tes";
         String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
 
         String title = "test";
         String productStatus = "중";
@@ -171,8 +172,8 @@ class TradePostServiceTest {
 
         for (int i = 0; i < lng; i++) {
 
-            authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword);
-            tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+            authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
+            tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime.plusMinutes(i));
 
             authorIds[i] = authorId;
             tradePostIds[i] = tradePostId;
@@ -185,14 +186,16 @@ class TradePostServiceTest {
             productStatus += i;
             description += i;
             price += i;
-            registrationTime = LocalDateTime.now();
         }
 
         List<TradePost> result = tradePostService.findTradePostsWithPaging(1, category, false);
 
         for (int i = 0; i < lng; i++) {
-            assertThat(result.get(i)).isEqualTo(tradePostService.findById(tradePostIds[i]));
-            assertThat(result.get(i).getAuthor()).isEqualTo(userService.findById(authorIds[i]));
+
+            int latestIdx = lng - i - 1;
+
+            assertThat(result.get(i).getId()).isEqualTo((int) tradePostIds[latestIdx]);
+            assertThat(result.get(i).getAuthor().getId()).isEqualTo((int) authorIds[latestIdx]);
         }
     }
 }

--- a/api/src/test/java/com/hcs/service/UserServiceTest.java
+++ b/api/src/test/java/com/hcs/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @EnableEncryptableProperties
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 class UserServiceTest {
 


### PR DESCRIPTION
- `JdbcTemplateHelper` 의 `user`, `comment` 삽입 함수 중, `registerationTime` 필드를 추가하지 않았습니다. 이를 추가하였습니다.
- service 테스트 시 `@EnableJpaRepositories` 를 추가하여 동작될 수 있도록 하였습니다.

- `user`, `tradePost`, `comment`의 `mapper`, `service` 테스트가 통과되었습니다

<img width="522" alt="스크린샷 2022-01-22 오후 10 23 42" src="https://user-images.githubusercontent.com/58963724/150640225-a85533eb-1389-46b3-b53c-01dcc9ea99d6.png">
