### PR TITLE
TradePostController - info

### DIFF
--- a/api/src/main/java/com/hcs/config/AppConfig.java
+++ b/api/src/main/java/com/hcs/config/AppConfig.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hcs.domain.Club;
+import com.hcs.domain.TradePost;
 import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInListDto;
-import com.hcs.dto.response.user.UserInfoDto;
 import com.hcs.dto.response.club.ClubInfoDto;
+import com.hcs.dto.response.tradePost.TradePostInfoDto;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.modelmapper.convention.NameTokenizers;
@@ -35,6 +37,10 @@ public class AppConfig {
 
         modelMapper.typeMap(Club.class, ClubInfoDto.class).addMappings(mapping -> {
             mapping.map(Club::getId, ClubInfoDto::setClubId);
+        });
+
+        modelMapper.typeMap(TradePost.class, TradePostInfoDto.class).addMappings(mapping -> {
+            mapping.map(TradePost::getId, TradePostInfoDto::setTradePostId);
         });
 
         return modelMapper;

--- a/api/src/main/java/com/hcs/controller/TradePostController.java
+++ b/api/src/main/java/com/hcs/controller/TradePostController.java
@@ -1,8 +1,15 @@
 package com.hcs.controller;
 
+import com.hcs.domain.TradePost;
+import com.hcs.domain.User;
 import com.hcs.dto.response.HcsResponse;
+import com.hcs.dto.response.method.HcsInfo;
+import com.hcs.dto.response.tradePost.TradePostInfoDto;
+import com.hcs.dto.response.user.UserInfoDto;
 import com.hcs.service.TradePostService;
+import com.hcs.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,7 +23,26 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class TradePostController {
 
+    private final ModelMapper modelMapper;
+    private final UserService userService;
     private final TradePostService tradePostService;
+    private final HcsInfo info;
+
+    @GetMapping("/info")
+    public HcsResponse tradePost(@RequestParam("tradePostId") long tradePostId) {
+
+        long authorId = tradePostService.findAuthorIdById(tradePostId);
+
+        TradePost tradePost = tradePostService.findById(tradePostId);
+        User author = userService.findById(authorId);
+
+        TradePostInfoDto tradePostInfoDto = modelMapper.map(tradePost, TradePostInfoDto.class);
+        UserInfoDto userInfoDto = modelMapper.map(author, UserInfoDto.class);
+
+        tradePostInfoDto.setAuthor(userInfoDto);
+
+        return HcsResponse.of(info.tradePost(tradePostInfoDto));
+    }
 
     @GetMapping("/list")
     public HcsResponse tradePosts(@RequestParam("page") int page, @RequestParam("category") String category, @RequestParam("salesStatus") boolean salesStatus) {

--- a/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsInfo.java
@@ -3,11 +3,10 @@ package com.hcs.dto.response.method;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.hcs.domain.Club;
-import com.hcs.dto.response.user.UserInfoDto;
-import com.hcs.domain.User;
 import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.club.ClubUserDto;
+import com.hcs.dto.response.tradePost.TradePostInfoDto;
+import com.hcs.dto.response.user.UserInfoDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -70,6 +69,17 @@ public class HcsInfo {
     public ObjectNode club(ClubInfoDto clubInfoDto) {
         ObjectNode hcs = objectMapper.createObjectNode();
         ObjectNode item = clubInfo(clubInfoDto);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+
+        return hcs;
+    }
+
+    public ObjectNode tradePost(TradePostInfoDto tradePostInfoDto) {
+
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.valueToTree(tradePostInfoDto);
 
         hcs.put("status", 200);
         hcs.set("item", item);

--- a/api/src/main/java/com/hcs/dto/response/tradePost/TradePostInfoDto.java
+++ b/api/src/main/java/com/hcs/dto/response/tradePost/TradePostInfoDto.java
@@ -1,0 +1,30 @@
+package com.hcs.dto.response.tradePost;
+
+import com.hcs.dto.response.user.UserInfoDto;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class TradePostInfoDto {
+
+    private long tradePostId;
+    private String title;
+
+    private UserInfoDto author;
+    private String productStatus;
+    private String category;
+    private String description;
+
+    // TODO : 클래스 파일 생성 및 사진에 대한 비즈니스 로직 작성
+//    private Set<Picture> pictures;
+
+    private String locationName;
+    private double lng;
+    private double lat;
+    private int price;
+    private int views;
+
+    private boolean salesStatus;
+    private LocalDateTime registerationTime;
+}

--- a/api/src/test/java/com/hcs/controller/TradePostControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/TradePostControllerTest.java
@@ -1,0 +1,98 @@
+package com.hcs.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hcs.annotation.EnableMockMvc;
+import com.hcs.common.JdbcTemplateHelper;
+import com.hcs.service.TradePostService;
+import com.hcs.service.UserService;
+import com.jayway.jsonpath.JsonPath;
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@EnableMockMvc
+@EnableEncryptableProperties
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
+@Transactional
+public class TradePostControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    TradePostService tradePostService;
+
+    @Autowired
+    JdbcTemplateHelper jdbcTemplateHelper;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @DisplayName("중고거래 정보 요청시 리턴되는 body를 확인")
+    @Test
+    void tradePostInfoTest() throws Exception {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        MvcResult mvcResult = mockMvc.perform(get("/post/tradePost/info")
+                        .param("tradePostId", String.valueOf(tradePostId)))
+
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = mvcResult.getResponse().getContentAsString();
+
+        int status = JsonPath.parse(response).read("$.HCS.status");
+        HashMap<String, Object> item = JsonPath.parse(response).read("$.HCS.item");
+
+        assertThat(status).isEqualTo(200);
+
+        assertThat(item.get("tradePostId")).isEqualTo((int) tradePostId);
+        assertThat(item.get("title")).isEqualTo(title);
+
+        LinkedHashMap author = (LinkedHashMap) item.get("author");
+
+        assertThat(author.get("userId")).isEqualTo((int) authorId);
+        assertThat(author.get("email")).isEqualTo(newEmail);
+        assertThat(author.get("nickname")).isEqualTo(newNickname);
+
+        assertThat(item.get("productStatus")).isEqualTo(productStatus);
+        assertThat(item.get("category")).isEqualTo(category);
+        assertThat(item.get("description")).isEqualTo(description);
+        assertThat(item.get("price")).isEqualTo(price);
+    }
+}


### PR DESCRIPTION
TradePostController - info 기능을 생성 및 테스트하였습니다.

- `TradePostInfoDto`
- info 요청시 author의 정보를 `UserInfoDto`로 매핑해서 `author` 필드로 내려주었습니다.
- `UserInfoDto` 는 `userId`, `email`, `nickname`, `emailVerifed`, `joinedAt`, `age`, `position`, `location` 등 보안상 노출되선 안되는 정보를 제외한 정보를 내려줍니다.

<img width="407" alt="스크린샷 2022-01-23 오후 1 48 01" src="https://user-images.githubusercontent.com/58963724/150665293-4ec0aa12-7549-47c7-92a4-dbfc7195411d.png">

