### PR TITLE
CommentList using JpaRepository for paging

### DIFF
--- a/api/src/main/java/com/hcs/domain/Comment.java
+++ b/api/src/main/java/com/hcs/domain/Comment.java
@@ -1,6 +1,5 @@
 package com.hcs.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,11 +12,14 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
+
+@NamedEntityGraph(name = "Comment.withAuthor", attributeNodes = {
+        @NamedAttributeNode(value = "author")}
+)
 
 @Data
 @Entity
@@ -34,7 +36,10 @@ public class Comment {
     private long id;
 
     @Column(name = "parentCommentId", insertable = false, updatable = false)
-    private long parentCommentId;
+    private Long parentCommentId;
+
+    @Column(name = "tradePostId", insertable = false, updatable = false)
+    private Long tradePostId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "authorId")
@@ -42,19 +47,6 @@ public class Comment {
 
     @Column(name = "contents")
     private String contents;
-
-    @ManyToOne
-    @JoinColumn(name = "tradePostId")
-    @JsonIgnore
-    private TradePost tradePost;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parentCommentId")
-    private Comment parentComment;
-
-    @OneToMany(mappedBy = "parentComment", fetch = FetchType.LAZY)
-    @JsonIgnore
-    private Set<Comment> replys = new HashSet<>();
 
     @Column(name = "registerationTime")
     private LocalDateTime registerationTime;

--- a/api/src/main/java/com/hcs/repository/CommentRepository.java
+++ b/api/src/main/java/com/hcs/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package com.hcs.repository;
+
+import com.hcs.domain.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @EntityGraph(value = "Comment.withAuthor", type = EntityGraph.EntityGraphType.LOAD)
+    Page<Comment> findListsByTradePostId(long tradePostId, Pageable pageable);
+}


### PR DESCRIPTION
`tradepost`의 `comment`들을 넘겨줄 때 `jpa`의 `page api`를 사용할 것이며 연관관계 객체들을 모두 가져오지 않고 단일 쿼리를 여러번 질의하는 방향으로 구현할것임.

- 연관관계 필드를 지우고 `fk colum`을 필드로 선언하였음
- 해당 `fk field`를 가지고 필요 시 추가 질의를 할 것임

예를 들어 댓글의 경우 **게시글의 댓글을 모두 가져오는 것이 아닌 5개씩 가져오며**
**페이지를 내릴때마다 다음 5개를 요청에 따라 리턴해줍니다**
또한 대댓글은 아래 사진과 같이 **답글 링크를 누르면 해당 대댓글 정보를 5개씩 내려줄 계획입니다**
<img width="506" alt="스크린샷 2022-01-23 오후 2 51 04" src="https://user-images.githubusercontent.com/58963724/150667471-9cbcbf2f-c910-4a28-b025-86578496b1cc.png">
(해당 사진은 페이스북 - 한국 스프링 사용자 모임의 포스트에서 가져왔으며 닉네임을 가렸음) 