### PR TITLE
tradePostService - findCommentsWithPaging

### DIFF
--- a/api/src/main/resources/mybatis-mapper/CommentMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/CommentMapperXml.xml
@@ -24,7 +24,7 @@
 
     <insert id="insertComment" useGeneratedKeys="true" keyProperty="id" parameterType="Comment">
         insert into Comment (authorId, contents, tradePostId, registerationTime)
-        values (#{author.id}, #{contents}, #{tradePost.id}, #{registerationTime})
+        values (#{author.id}, #{contents}, #{tradePostId}, #{registerationTime})
         <selectKey keyProperty="id" resultType="long" order="AFTER">
             SELECT LAST_INSERT_ID()
         </selectKey>
@@ -32,7 +32,7 @@
 
     <insert id="insertReply" useGeneratedKeys="true" keyProperty="id" parameterType="Comment">
         insert into Comment (parentCommentId, authorId, contents, tradePostId, registerationTime)
-        values (#{parentCommentId}, #{author.id}, #{contents}, #{tradePost.id}, #{registerationTime})
+        values (#{parentCommentId}, #{author.id}, #{contents}, #{tradePostId}, #{registerationTime})
         <selectKey keyProperty="id" resultType="long" order="AFTER">
             SELECT LAST_INSERT_ID()
         </selectKey>

--- a/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/CommentMapperTest.java
@@ -2,7 +2,6 @@ package com.hcs.mapper;
 
 import com.hcs.common.JdbcTemplateHelper;
 import com.hcs.domain.Comment;
-import com.hcs.domain.TradePost;
 import com.hcs.domain.User;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.junit.jupiter.api.DisplayName;
@@ -297,16 +296,13 @@ class CommentMapperTest {
     private Comment makeTestComment(long authorId, long tradePostId, String contents) {
 
         User testUser = new User(); // Dummy 데이터
-        TradePost testTradePost = new TradePost();
 
         testUser.setId(authorId);
-        testTradePost.setId(tradePostId);
 
         Comment testComment = Comment.builder()
                 .author(testUser)
                 .contents(contents)
-                .tradePost(testTradePost)
-                .replys(null)
+                .tradePostId(tradePostId)
                 .registerationTime(LocalDateTime.now())
                 .build();
 
@@ -316,17 +312,14 @@ class CommentMapperTest {
     private Comment makeTestReply(long parentCommentId, long authorId, long tradePostId, String contents) {
 
         User testUser = new User(); // Dummy 데이터
-        TradePost testTradePost = new TradePost();
 
         testUser.setId(authorId);
-        testTradePost.setId(tradePostId);
 
         Comment testComment = Comment.builder()
                 .parentCommentId(parentCommentId)
                 .author(testUser)
                 .contents(contents)
-                .tradePost(testTradePost)
-                .replys(null)
+                .tradePostId(tradePostId)
                 .registerationTime(LocalDateTime.now())
                 .build();
 

--- a/api/src/test/java/com/hcs/service/CommentServiceTest.java
+++ b/api/src/test/java/com/hcs/service/CommentServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,6 +42,41 @@ class CommentServiceTest {
 
     @Autowired
     JdbcTemplateHelper jdbcTemplateHelper;
+
+    @Test
+    @DisplayName("중고거래 게시글에 달린 댓글들을 페이지당 리스트로 리턴하는 테스트")
+    void findCommentsByTradePostIdTest() {
+
+        String newEmail = "test@naver.com";
+        String newNickname = "test";
+        String newPassword = "password";
+        LocalDateTime joinedAt = LocalDateTime.now();
+
+        long authorId = jdbcTemplateHelper.insertTestUser(newEmail, newNickname, newPassword, joinedAt);
+        String title = "test";
+        String productStatus = "중";
+        String category = "중";
+        String description = "중";
+        int price = 10000;
+        int salesStatus = 0;
+        LocalDateTime registrationTime = LocalDateTime.now();
+
+        long tradePostId = jdbcTemplateHelper.insertTestTradePost(authorId, title, productStatus, category, description, price, salesStatus, registrationTime);
+
+        int lng = 5;
+
+        String contents = "test 댓글내용";
+        LocalDateTime comment_registerationTime = LocalDateTime.now();
+
+        for (int i = 0; i < lng; i++) {
+            jdbcTemplateHelper.insertTestComment(0, authorId, tradePostId, contents + i, comment_registerationTime.plusSeconds(i));
+        }
+
+        List<Comment> comments = commentService.findCommentsWithPaging(1, tradePostId);
+        System.out.println("comments " + comments);
+
+        assertThat(comments.size()).isEqualTo(lng);
+    }
 
     @Test
     @DisplayName("Comment 추가가 제대로 동작하는지 테스트")


### PR DESCRIPTION
`findCommentsWithPaging()` 
- 페이지당 5개씩 댓글을 리턴해주는 page api를 생성하였습니다.
- 페이지는 최신순으로 리턴됩니다.
- 이를 테스트하였습니다.
- 또한 엔티티 객체의 연관관계 객체들을 지우는 대신 pk field를 생성하였으므로 insert 문과 builder 사용문을 고쳤습니다.
- 댓글 저장시에 날짜 입력이 누락 상태였습니다. 생성날짜 필드에 값을 넣어주는 set메서드를 추가하였습니다.
