### PR TITLE
Club  - member 탈퇴 기능 추가

### DIFF
--- a/api/src/main/java/com/hcs/controller/ClubController.java
+++ b/api/src/main/java/com/hcs/controller/ClubController.java
@@ -8,6 +8,7 @@ import com.hcs.dto.response.club.ClubExpulsionDto;
 import com.hcs.dto.response.club.ClubInListDto;
 import com.hcs.dto.response.club.ClubInfoDto;
 import com.hcs.dto.response.club.ClubJoinDto;
+import com.hcs.dto.response.club.ClubResignDto;
 import com.hcs.dto.response.method.HcsDelete;
 import com.hcs.dto.response.method.HcsInfo;
 import com.hcs.dto.response.method.HcsList;
@@ -85,7 +86,7 @@ public class ClubController {
         return HcsResponse.of(delete.club(clubId));
     }
 
-    @PostMapping("/members")
+    @PostMapping("/members") // TODO : member 로 변경예정
     public HcsResponse joinClubAsMember(@RequestParam("clubId") long clubId, @RequestParam("userEmail") String userEmail) {
         //TODO : 보안 설정 후 userEmail 변경
         User user = userService.findByEmail(userEmail);
@@ -93,12 +94,21 @@ public class ClubController {
         return HcsResponse.of(submit.joinClub(clubJoinDto));
     }
 
-    @DeleteMapping("/delete/members")
-    public HcsResponse expulsionMember(@RequestParam("clubId") long clubId, @RequestParam("managerEmail") String managerEmail,@RequestParam("userId") long userId) {
+    @DeleteMapping("/delete/members") // TODO : member 로 변경예정
+    public HcsResponse expulsionMember(@RequestParam("clubId") long clubId, @RequestParam("managerEmail") String managerEmail, @RequestParam("userId") long userId) {
         //TODO : 보안 설정 후 userEmail 변경
         Club club = clubService.expulsionMember(clubId, managerEmail, userId);
         ClubExpulsionDto dto = new ClubExpulsionDto(userId, club.getMemberCount());
         return HcsResponse.of(delete.expulsion(dto));
+    }
+
+    @DeleteMapping("/resign/member")
+    public HcsResponse resignMember(@RequestParam("clubId") long clubId, @RequestParam("userEmail") String userEmail) {
+        //TODO : 보안 설정 후 userEmail 변경
+        User user = userService.findByEmail(userEmail);
+        Club club = clubService.resignMember(clubId, user.getId());
+        ClubResignDto dto = new ClubResignDto(user.getId(), club.getMemberCount());
+        return HcsResponse.of(delete.resignMember(dto));
     }
 
 }

--- a/api/src/main/java/com/hcs/dto/response/club/ClubResignDto.java
+++ b/api/src/main/java/com/hcs/dto/response/club/ClubResignDto.java
@@ -1,0 +1,11 @@
+package com.hcs.dto.response.club;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ClubResignDto {
+    private long resignedId;
+    private int currentMemberCount;
+}

--- a/api/src/main/java/com/hcs/dto/response/method/HcsDelete.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsDelete.java
@@ -3,6 +3,7 @@ package com.hcs.dto.response.method;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hcs.dto.response.club.ClubExpulsionDto;
+import com.hcs.dto.response.club.ClubResignDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -36,7 +37,20 @@ public class HcsDelete {
         return hcs;
     }
 
-    public ObjectNode expulsion(ClubExpulsionDto dto) {
+    public ObjectNode expulsion(ClubExpulsionDto dto) { //TODO : expulsionMember 로 이름 변경 예정
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.createObjectNode();
+
+        ObjectNode member = objectMapper.valueToTree(dto);
+        item.set("member", member);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+
+        return hcs;
+    }
+
+    public ObjectNode resignMember(ClubResignDto dto) {
         ObjectNode hcs = objectMapper.createObjectNode();
         ObjectNode item = objectMapper.createObjectNode();
 

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -169,4 +169,21 @@ public class ClubService {
         }
         return club;
     }
+
+    public Club resignMember(long clubId, long memberId) {
+        Club club = getClub(clubId);
+        if (!clubMapper.checkClubMember(club.getId(), memberId)) {
+            throw new NotJoinedClubException();
+        }
+        int deleteMemberResult = clubMapper.deleteMember(club.getId(), memberId);
+        if (deleteMemberResult != 1) {
+            throw new DatabaseException("DB member error");
+        }
+        club.setMemberCount(club.getMemberCount() - 1);
+        int updateMemberCountResult = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
+        if (updateMemberCountResult != 1) {
+            throw new DatabaseException("DB club error");
+        }
+        return club;
+    }
 }

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -308,7 +308,31 @@ class ClubServiceTest {
         then(clubMapper).should(times(2)).checkClubManager(anyLong(), anyLong());
         then(clubMapper).should(times(1)).deleteMember(anyLong(), anyLong());
         then(clubMapper).should(times(1)).updateMemberCount(anyLong(), anyInt());
-        assertEquals(beforeMemberCount - 1, club.getManagerCount());
+        assertEquals(beforeMemberCount - 1, club.getMemberCount());
+
+    }
+
+    @DisplayName("clubId 와 member id 가 주어지면,  club member에서 삭제")
+    @Test
+    void resignMember() {
+        //given
+        User user = fixtureUser_2;
+        Club givenClub = fixtureClub;
+        int beforeMemberCount = 1;
+        givenClub.setMemberCount(beforeMemberCount);
+        given(clubMapper.findById(givenClub.getId())).willReturn(givenClub);
+        given(clubMapper.checkClubMember(anyLong(), anyLong())).willReturn(true);
+        given(clubMapper.deleteMember(anyLong(), anyLong())).willReturn(1);
+        given(clubMapper.updateMemberCount(anyLong(), anyInt())).willReturn(1);
+
+        //when
+        Club club = clubService.resignMember(givenClub.getId(), user.getId());
+
+        //then
+        then(clubMapper).should(times(1)).checkClubMember(anyLong(), anyLong());
+        then(clubMapper).should(times(1)).deleteMember(anyLong(), anyLong());
+        then(clubMapper).should(times(1)).updateMemberCount(anyLong(), anyInt());
+        assertEquals(beforeMemberCount - 1, club.getMemberCount());
 
     }
 


### PR DESCRIPTION
Club member 스스로 탈퇴 신청을 하는 기능 추가 
- `Club` 
controller , service 기능 추가(mapper는 이미 작성한 method 사용) , 테스트 작성 및 통과 완료
![image](https://user-images.githubusercontent.com/29278980/150692631-6e307322-3548-4824-9dfb-2f9a0db1458c.png)
- `Response`
탈퇴 응답을 위한 `ClubResignDto` 작성
- 주석추가 : club 기능 중 member 관련 url 수정예정  `members`->`member` 
