### PR TITLE
TradePostController - modify

### DIFF
--- a/api/src/main/java/com/hcs/controller/TradePostController.java
+++ b/api/src/main/java/com/hcs/controller/TradePostController.java
@@ -104,9 +104,10 @@ public class TradePostController {
     private void modifyTradePostValidation(long tradePostId, String title) throws MethodArgumentNotValidException {
 
         TradePost originTradePost = tradePostService.findById(tradePostId);
-        Errors errors = new MapBindingResult(new HashMap<>(), "a");
 
         if (originTradePost.getTitle() != title && tradePostService.countByTitle(title) > 0) {
+
+            Errors errors = new MapBindingResult(new HashMap<>(), "a");
 
             errors.rejectValue("title", "invalid.title", new Object[]{title}, "이미 사용중인 제목 입니다.");
             throw new MethodArgumentNotValidException(null, (BindingResult) errors);

--- a/api/src/main/java/com/hcs/dto/response/method/HcsModify.java
+++ b/api/src/main/java/com/hcs/dto/response/method/HcsModify.java
@@ -33,4 +33,15 @@ public class HcsModify {
         hcs.set("item", item);
         return hcs;
     }
+
+    public ObjectNode tradePost(long tradePostId) {
+        ObjectNode hcs = objectMapper.createObjectNode();
+        ObjectNode item = objectMapper.createObjectNode();
+
+        item.put("tradePostId", tradePostId);
+
+        hcs.put("status", 200);
+        hcs.set("item", item);
+        return hcs;
+    }
 }

--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -92,6 +92,10 @@ public class TradePostService {
         return result;
     }
 
+    public int countByTitle(String title) {
+        return tradePostMapper.countByTitle(title);
+    }
+
     public long deleteTradePostById(long Id) {
         return tradePostMapper.deleteTradePostById(Id);
     }


### PR DESCRIPTION
`TradePostController` - `modify` 기능 및 테스트 코드를 생성하였습니다.

- put method로 요청할 경우 수정작업이 이루어집니다.
- 총 두번의 검증 과정을 거칩니다.
- `@Valid` 어노테이션을 달아줌으로써 `javax.validation.constraints`에서 제공하는 검증 어노테이션들을 dto의 필드들이 통과되어야 함
- 이후 `title`의 중복 체크를 `controller` 단의 `modifyTradePostValidation()` 가 처리함
- 모든 테스트를 통과하였습니다
<img width="410" alt="스크린샷 2022-01-24 오후 9 19 30" src="https://user-images.githubusercontent.com/58963724/150782795-93b63edd-111f-4859-b21c-e67da9f083ae.png">