### PR TITLE
Exception - RuntimeException

### DIFF
--- a/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
+++ b/api/src/main/java/com/hcs/controller/advisor/ExceptionAdvisor.java
@@ -7,7 +7,6 @@ import com.hcs.exception.club.AlreadyJoinedClubAsManagerException;
 import com.hcs.exception.club.AlreadyJoinedClubException;
 import com.hcs.exception.club.ClubAccessDeniedException;
 import com.hcs.exception.club.NotJoinedClubException;
-import com.hcs.exception.global.DatabaseException;
 import com.hcs.exception.result.ExceptionResult;
 import com.hcs.exception.result.ValidationResult;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,12 +65,14 @@ public class ExceptionAdvisor {
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler(DatabaseException.class)
-    public HcsResponse DatabaseExceptionHandler(DatabaseException e) {
+    @ExceptionHandler(RuntimeException.class)
+    public HcsResponse RuntimeExceptionHandler(RuntimeException e) {
 
-        ErrorCode error = ErrorCode.DATABASE_ERROR;
-
-        return HcsResponse.of(hcsException.exceptionAndLocation(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage()), e.getMessage()));
+        ErrorCode error = ErrorCode.RUNTIME;
+        if (!e.getMessage().isEmpty()) {
+            return HcsResponse.of(hcsException.exception(error.getStatus(), new ExceptionResult(error.getErrorCode(), e.getMessage())));
+        }
+        return HcsResponse.of(hcsException.exception(error.getStatus(), new ExceptionResult(error.getErrorCode(), error.getMessage())));
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/api/src/main/java/com/hcs/exception/ErrorCode.java
+++ b/api/src/main/java/com/hcs/exception/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
 
     METHOD_ARGUMENT_NOT_VALID(400, -1, "request body로 전송된 데이터가 검증단계를 통과하지 못함"),
     NUMBER_FORMAT(400, -2, "숫자형으로 요청해주세요"),
-    DATABASE_ERROR(500, -3, "db access error"),
+    RUNTIME(500, -3, "runtime error"),
     ILLEGAL_ARGUMENT(400, -4, "잘못된 argument 입니다"),
 
     CLUB_ACCESS_DENIED(400, -100, "해당 club 의 manager 만 접근이 가능합니다"),

--- a/api/src/main/java/com/hcs/exception/global/DatabaseException.java
+++ b/api/src/main/java/com/hcs/exception/global/DatabaseException.java
@@ -1,7 +1,0 @@
-package com.hcs.exception.global;
-
-public class DatabaseException extends RuntimeException{
-    public DatabaseException(String message) {
-        super(message);
-    }
-}

--- a/api/src/main/java/com/hcs/mapper/ClubMapper.java
+++ b/api/src/main/java/com/hcs/mapper/ClubMapper.java
@@ -30,7 +30,7 @@ public interface ClubMapper {
 
     int joinManagerById(@Param("clubId") long clubId, @Param("managerId") long userId);
 
-    int deleteClub(@Param("clubId") long clubId, @Param("managerId") long userId);
+    int deleteClub(@Param("clubId") long clubId);
 
     List<Club> findAllClubs();
 

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -11,7 +11,6 @@ import com.hcs.exception.club.AlreadyJoinedClubAsManagerException;
 import com.hcs.exception.club.AlreadyJoinedClubException;
 import com.hcs.exception.club.ClubAccessDeniedException;
 import com.hcs.exception.club.NotJoinedClubException;
-import com.hcs.exception.global.DatabaseException;
 import com.hcs.mapper.ClubMapper;
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.RowBounds;
@@ -43,11 +42,11 @@ public class ClubService {
 
         int insertClubResult = clubMapper.insertClub(club);
         if (insertClubResult != 1) {
-            throw new DatabaseException("DB club insert");
+            throw new RuntimeException("DB error");
         }
         int insertManagerResult = clubMapper.joinManagerById(club.getId(), userId);
         if (insertManagerResult != 1) {
-            throw new DatabaseException("DB club manager insert");
+            throw new RuntimeException("DB error");
         }
         return club;
     }
@@ -115,7 +114,7 @@ public class ClubService {
         checkAlreadyJoinedClub(club, user);
         int result = clubMapper.joinMemberById(club.getId(), user.getId());
         if (result != 1) {
-            throw new DatabaseException("DB club_members insert error");
+            throw new RuntimeException("DB error");
         }
         plusMemberCount(club);
         ClubJoinDto dto = new ClubJoinDto(user.getId(), club.getMemberCount());
@@ -133,7 +132,7 @@ public class ClubService {
         club.setMemberCount(club.getMemberCount() + 1);
         int result = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
         if (result != 1) {
-            throw new DatabaseException("DB club memberCount update");
+            throw new RuntimeException("DB error");
         }
     }
 
@@ -160,13 +159,13 @@ public class ClubService {
 
         int deleteMemberResult = clubMapper.deleteMember(club.getId(), member.getId());
         if (deleteMemberResult != 1) {
-            throw new DatabaseException("DB club member delete");
+            throw new RuntimeException("DB error");
         }
 
         club.setMemberCount(club.getMemberCount() - 1);
         int updateMemberCountResult = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
         if (updateMemberCountResult != 1) {
-            throw new DatabaseException("DB club memberCount update");
+            throw new RuntimeException("DB error");
         }
         return club;
     }
@@ -178,12 +177,12 @@ public class ClubService {
         }
         int deleteMemberResult = clubMapper.deleteMember(club.getId(), memberId);
         if (deleteMemberResult != 1) {
-            throw new DatabaseException("DB member error");
+            throw new RuntimeException("DB error");
         }
         club.setMemberCount(club.getMemberCount() - 1);
         int updateMemberCountResult = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
         if (updateMemberCountResult != 1) {
-            throw new DatabaseException("DB club error");
+            throw new RuntimeException("DB error");
         }
         return club;
     }
@@ -207,22 +206,22 @@ public class ClubService {
 
         int deleteMember = clubMapper.deleteMember(club.getId(), member.getId());
         if (deleteMember != 1) {
-            throw new DatabaseException("DB club member error");
+            throw new RuntimeException("DB error");
         }
         club.setMemberCount(club.getMemberCount() - 1);
         int updateMemberCount = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
         if (updateMemberCount != 1) {
-            throw new DatabaseException("DB club error");
+            throw new RuntimeException("DB error");
         }
 
         int insertManager = clubMapper.joinManagerById(club.getId(), member.getId());
         if (insertManager != 1) {
-            throw new DatabaseException("DB club manager error");
+            throw new RuntimeException("DB error");
         }
         club.setManagerCount(club.getManagerCount() + 1);
         int updateManagerCount = clubMapper.updateManagerCount(club.getId(), club.getManagerCount());
         if (updateManagerCount != 1) {
-            throw new DatabaseException("DB club error");
+            throw new RuntimeException("DB error");
         }
 
         return club;

--- a/api/src/main/java/com/hcs/service/ClubService.java
+++ b/api/src/main/java/com/hcs/service/ClubService.java
@@ -40,14 +40,10 @@ public class ClubService {
         club.setCreatedAt(LocalDateTime.now());
         club.setManagerCount(1);
 
-        int insertClubResult = clubMapper.insertClub(club);
-        if (insertClubResult != 1) {
-            throw new RuntimeException("DB error");
-        }
-        int insertManagerResult = clubMapper.joinManagerById(club.getId(), userId);
-        if (insertManagerResult != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.insertClub(club);
+
+        clubMapper.joinManagerById(club.getId(), userId);
+
         return club;
     }
 
@@ -102,20 +98,20 @@ public class ClubService {
     }
 
     public long deleteClub(long clubId, long managerId) {
-        int result = clubMapper.deleteClub(clubId, managerId);
-        if (result != 1) {
+        Club club = getClub(clubId);
+        boolean isManager = clubMapper.checkClubManager(club.getId(), managerId);
+        if(!isManager){
             throw new ClubAccessDeniedException();
         }
-        return clubId;
+        clubMapper.deleteClub(club.getId());
+        return club.getId();
     }
 
     public ClubJoinDto joinClub(long clubId, User user) {
         Club club = getClub(clubId);
         checkAlreadyJoinedClub(club, user);
-        int result = clubMapper.joinMemberById(club.getId(), user.getId());
-        if (result != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.joinMemberById(club.getId(), user.getId());
+
         plusMemberCount(club);
         ClubJoinDto dto = new ClubJoinDto(user.getId(), club.getMemberCount());
         return dto;
@@ -130,10 +126,7 @@ public class ClubService {
 
     public void plusMemberCount(Club club) {
         club.setMemberCount(club.getMemberCount() + 1);
-        int result = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
-        if (result != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
     }
 
     public Club expulsionMember(long clubId, String managerEmail, long userId) {
@@ -157,16 +150,11 @@ public class ClubService {
 
         }
 
-        int deleteMemberResult = clubMapper.deleteMember(club.getId(), member.getId());
-        if (deleteMemberResult != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.deleteMember(club.getId(), member.getId());
 
         club.setMemberCount(club.getMemberCount() - 1);
-        int updateMemberCountResult = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
-        if (updateMemberCountResult != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
+
         return club;
     }
 
@@ -175,15 +163,10 @@ public class ClubService {
         if (!clubMapper.checkClubMember(club.getId(), memberId)) {
             throw new NotJoinedClubException();
         }
-        int deleteMemberResult = clubMapper.deleteMember(club.getId(), memberId);
-        if (deleteMemberResult != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.deleteMember(club.getId(), memberId);
+
         club.setMemberCount(club.getMemberCount() - 1);
-        int updateMemberCountResult = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
-        if (updateMemberCountResult != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
         return club;
     }
 
@@ -204,25 +187,15 @@ public class ClubService {
             throw new NotJoinedClubException();
         }
 
-        int deleteMember = clubMapper.deleteMember(club.getId(), member.getId());
-        if (deleteMember != 1) {
-            throw new RuntimeException("DB error");
-        }
-        club.setMemberCount(club.getMemberCount() - 1);
-        int updateMemberCount = clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
-        if (updateMemberCount != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.deleteMember(club.getId(), member.getId());
 
-        int insertManager = clubMapper.joinManagerById(club.getId(), member.getId());
-        if (insertManager != 1) {
-            throw new RuntimeException("DB error");
-        }
+        club.setMemberCount(club.getMemberCount() - 1);
+        clubMapper.updateMemberCount(club.getId(), club.getMemberCount());
+
+        clubMapper.joinManagerById(club.getId(), member.getId());
+
         club.setManagerCount(club.getManagerCount() + 1);
-        int updateManagerCount = clubMapper.updateManagerCount(club.getId(), club.getManagerCount());
-        if (updateManagerCount != 1) {
-            throw new RuntimeException("DB error");
-        }
+        clubMapper.updateManagerCount(club.getId(), club.getManagerCount());
 
         return club;
     }

--- a/api/src/main/java/com/hcs/service/CommentService.java
+++ b/api/src/main/java/com/hcs/service/CommentService.java
@@ -4,7 +4,6 @@ import com.hcs.domain.Comment;
 import com.hcs.domain.TradePost;
 import com.hcs.domain.User;
 import com.hcs.dto.request.CommentDto;
-import com.hcs.exception.global.DatabaseException;
 import com.hcs.mapper.CommentMapper;
 import com.hcs.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +31,7 @@ public class CommentService {
         comment.setRegisterationTime(LocalDateTime.now());
 
         long isSuccess = commentMapper.insertComment(comment);
-        if (isSuccess != 1) throw new DatabaseException("DB comment insert");
+        if (isSuccess != 1) throw new RuntimeException("DB error");
 
         return comment.getId();
     }
@@ -46,7 +45,7 @@ public class CommentService {
         reply.setRegisterationTime(LocalDateTime.now());
 
         long isSuccess = commentMapper.insertReply(reply);
-        if (isSuccess != 1) throw new DatabaseException("DB reply insert");
+        if (isSuccess != 1) throw new RuntimeException("DB error");
 
         return reply.getId();
     }
@@ -91,7 +90,7 @@ public class CommentService {
         int isSuccess = commentMapper.updateComment(comment);
 
         if (isSuccess != 1) {
-            throw new DatabaseException("DB user modify");
+            throw new RuntimeException("DB error");
         }
 
         return comment.getId();

--- a/api/src/main/java/com/hcs/service/CommentService.java
+++ b/api/src/main/java/com/hcs/service/CommentService.java
@@ -30,8 +30,7 @@ public class CommentService {
         comment.setTradePostId(tradePost.getId());
         comment.setRegisterationTime(LocalDateTime.now());
 
-        long isSuccess = commentMapper.insertComment(comment);
-        if (isSuccess != 1) throw new RuntimeException("DB error");
+        commentMapper.insertComment(comment);
 
         return comment.getId();
     }
@@ -44,8 +43,7 @@ public class CommentService {
         reply.setParentCommentId(parentCommentId);
         reply.setRegisterationTime(LocalDateTime.now());
 
-        long isSuccess = commentMapper.insertReply(reply);
-        if (isSuccess != 1) throw new RuntimeException("DB error");
+        commentMapper.insertReply(reply);
 
         return reply.getId();
     }
@@ -87,11 +85,7 @@ public class CommentService {
         String contents = commentDto.getContents();
         comment.setContents(contents);
 
-        int isSuccess = commentMapper.updateComment(comment);
-
-        if (isSuccess != 1) {
-            throw new RuntimeException("DB error");
-        }
+        commentMapper.updateComment(comment);
 
         return comment.getId();
     }

--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -34,22 +34,13 @@ public class TradePostService {
         tradePost.setSalesStatus(false);
         tradePost.setRegisterationTime(registrationTime);
 
-        int isSuccess = tradePostMapper.insertTradePost(tradePost);
-
-        if (isSuccess != 1) {
-            throw new RuntimeException("DB error");
-        }
+        tradePostMapper.insertTradePost(tradePost);
 
         return tradePost;
     }
 
     public void clickTradePost(long Id) {
-
-        int isSuccess = tradePostMapper.updateTradePostForView(Id);
-
-        if (isSuccess != 1) {
-            throw new RuntimeException("DB error");
-        }
+        tradePostMapper.updateTradePostForView(Id);
     }
 
     public long modifyTradePost(long Id, TradePostDto tradePostDto) {
@@ -59,11 +50,7 @@ public class TradePostService {
         tradePost = modelMapper.map(tradePostDto, TradePost.class);
         tradePost.setId(Id);
 
-        int isSuccess = tradePostMapper.updateTradePost(tradePost);
-
-        if (isSuccess != 1) {
-            throw new RuntimeException("DB error");
-        }
+        tradePostMapper.updateTradePost(tradePost);
 
         return tradePost.getId();
     }

--- a/api/src/main/java/com/hcs/service/TradePostService.java
+++ b/api/src/main/java/com/hcs/service/TradePostService.java
@@ -3,7 +3,6 @@ package com.hcs.service;
 import com.hcs.domain.TradePost;
 import com.hcs.domain.User;
 import com.hcs.dto.request.TradePostDto;
-import com.hcs.exception.global.DatabaseException;
 import com.hcs.mapper.TradePostMapper;
 import com.hcs.repository.TradePostRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +37,7 @@ public class TradePostService {
         int isSuccess = tradePostMapper.insertTradePost(tradePost);
 
         if (isSuccess != 1) {
-            throw new DatabaseException("DB tradePost click");
+            throw new RuntimeException("DB error");
         }
 
         return tradePost;
@@ -49,7 +48,7 @@ public class TradePostService {
         int isSuccess = tradePostMapper.updateTradePostForView(Id);
 
         if (isSuccess != 1) {
-            throw new DatabaseException("DB tradePost click");
+            throw new RuntimeException("DB error");
         }
     }
 
@@ -63,7 +62,7 @@ public class TradePostService {
         int isSuccess = tradePostMapper.updateTradePost(tradePost);
 
         if (isSuccess != 1) {
-            throw new DatabaseException("DB tradePost modify");
+            throw new RuntimeException("DB error");
         }
 
         return tradePost.getId();

--- a/api/src/main/java/com/hcs/service/UserService.java
+++ b/api/src/main/java/com/hcs/service/UserService.java
@@ -3,7 +3,6 @@ package com.hcs.service;
 import com.hcs.domain.User;
 import com.hcs.dto.request.SignUpDto;
 import com.hcs.dto.request.UserModifyDto;
-import com.hcs.exception.global.DatabaseException;
 import com.hcs.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -27,7 +26,7 @@ public class UserService {
         long isSuccess = insertUser(user);
 
         if (isSuccess != 1) {
-            throw new DatabaseException("DB user insert");
+            throw new RuntimeException("DB error");
         }
 
         return user;
@@ -63,7 +62,7 @@ public class UserService {
         int isSuccess = userMapper.updateUser(user);
 
         if (isSuccess != 1) {
-            throw new DatabaseException("DB user modify");
+            throw new RuntimeException("DB error");
         }
 
         return user.getId();

--- a/api/src/main/java/com/hcs/service/UserService.java
+++ b/api/src/main/java/com/hcs/service/UserService.java
@@ -23,11 +23,7 @@ public class UserService {
 
         User user = modelMapper.map(signUpDto, User.class);
 
-        long isSuccess = insertUser(user);
-
-        if (isSuccess != 1) {
-            throw new RuntimeException("DB error");
-        }
+        insertUser(user);
 
         return user;
     }
@@ -59,11 +55,7 @@ public class UserService {
         user = modelMapper.map(userModifyDto, User.class);
         user.setId(userId);
 
-        int isSuccess = userMapper.updateUser(user);
-
-        if (isSuccess != 1) {
-            throw new RuntimeException("DB error");
-        }
+        userMapper.updateUser(user);
 
         return user.getId();
     }

--- a/api/src/main/resources/mybatis-mapper/ClubMapperXml.xml
+++ b/api/src/main/resources/mybatis-mapper/ClubMapperXml.xml
@@ -81,9 +81,7 @@
     <delete id="deleteClub" parameterType="long">
         delete c
         from Club c
-                 inner join club_managers cm on c.id = cm.clubId
         where c.id = #{clubId}
-          AND cm.managerId = #{managerId}
     </delete>
 
     <select id="findAllClubs" resultType="Club">

--- a/api/src/test/java/com/hcs/controller/ExceptionAdvisorTest.java
+++ b/api/src/test/java/com/hcs/controller/ExceptionAdvisorTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -23,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @EnableMockMvc
 @EnableEncryptableProperties
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 public class ExceptionAdvisorTest {
     @Autowired

--- a/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
+++ b/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @EnableMockMvc
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 class ClubDtoValidationTest {
 
@@ -40,7 +42,7 @@ class ClubDtoValidationTest {
         clubDto.setCategory("sports");
         clubDto.setLocation("Bucheon");
 
-        mockMvc.perform(post("/club/submit")
+        mockMvc.perform(post("/club")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(clubDto))
                         .accept(MediaType.APPLICATION_JSON))

--- a/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
+++ b/api/src/test/java/com/hcs/mapper/ClubMapperTest.java
@@ -104,10 +104,9 @@ class ClubMapperTest {
     void deleteTest() {
         //given
         Club club = fixtureClub;
-        User manager = fixtureManager;
 
         //when
-        int result = clubMapper.deleteClub(club.getId(), manager.getId());
+        int result = clubMapper.deleteClub(club.getId());
 
         //then
         Club newClub = clubMapper.findById(club.getId());

--- a/api/src/test/java/com/hcs/service/ClubServiceTest.java
+++ b/api/src/test/java/com/hcs/service/ClubServiceTest.java
@@ -233,9 +233,11 @@ class ClubServiceTest {
     @Test
     void deleteClub() {
         //given
-        long givenClubId = 1L;
+        long givenClubId = fixtureClub.getId();
         long givenManagerId = 2L;
-        given(clubMapper.deleteClub(givenClubId, givenManagerId)).willReturn(1);
+        given(clubMapper.findById(givenClubId)).willReturn(fixtureClub);
+        given(clubMapper.deleteClub(givenClubId)).willReturn(1);
+        given(clubMapper.checkClubManager(givenClubId, givenManagerId)).willReturn(true);
 
         //when
         long deletedClubId = clubService.deleteClub(givenClubId, givenManagerId);
@@ -341,7 +343,7 @@ class ClubServiceTest {
     @DisplayName("club id 와 managerEmail, member id 가 주어지면 member 를 manager 로 만들기")
     @ParameterizedTest
     @ValueSource(ints = {5, 10, 20})
-    void makeManager(int givenNumber ) {
+    void makeManager(int givenNumber) {
         //given
         Club givenClub = fixtureClub;
         givenClub.setManagerCount(givenNumber);

--- a/api/src/test/java/com/hcs/setting/JpaWithMybatisTests.java
+++ b/api/src/test/java/com/hcs/setting/JpaWithMybatisTests.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -18,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @SpringBootTest
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 public class JpaWithMybatisTests {
 

--- a/api/src/test/java/com/hcs/validator/UserValidationTest.java
+++ b/api/src/test/java/com/hcs/validator/UserValidationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @EnableMockMvc
 @EnableEncryptableProperties
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 public class UserValidationTest {
 


### PR DESCRIPTION
(수정)DB error 관련 기존 `DatabaseException` 사용하던 코드를 **삭제했습니다.**
mapper 사용시 **return 값으로 에러를 판별하던 로직을 제거**하고, 에러발생시 advisor 에서 `RuntimeException` 으로핸들링 할 수 있도록 핸들러를 구현했습니다.
`RuntimeException` 이 throw 될때 `message` 가 있다면 `ErrorCode` 에 정의된 메세지 대신 해당 `message` 를 사용합니다.

- `exception`
`DatabaseException` 삭제
`DatabaseException` 가 사용하던 `ErrorCode` - 3 번을 `RuntimeException` 이 사용하도록 변경
advisor 에서 `RuntimeExceptionHandler` 구현

- `test`
깨진 테스트 수정 및 테스트 통과 
mapper return 로직 제거에 따른 deleteClub xml 쿼리 수정및 테스트 수정