### PR TITLE
Datasource 관련 설정 DatasourceConfig 로 이동 및 테스트 수정

### DIFF
--- a/api/src/main/java/com/hcs/Application.java
+++ b/api/src/main/java/com/hcs/Application.java
@@ -11,8 +11,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
  * @EnableCaching : 캐시 관리 기능 활성화
  **/
 @EnableCaching
-@MapperScan(value = {"com.hcs.mapper"})
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @SpringBootApplication
 public class Application {
     public static void main(String[] args) {

--- a/api/src/main/java/com/hcs/Application.java
+++ b/api/src/main/java/com/hcs/Application.java
@@ -4,6 +4,7 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
  * @SpringBootApplication : auto-configuration을 담당하는 어노테이션
@@ -11,6 +12,7 @@ import org.springframework.cache.annotation.EnableCaching;
  **/
 @EnableCaching
 @MapperScan(value = {"com.hcs.mapper"})
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @SpringBootApplication
 public class Application {
     public static void main(String[] args) {

--- a/api/src/main/java/com/hcs/config/DataSourceConfig.java
+++ b/api/src/main/java/com/hcs/config/DataSourceConfig.java
@@ -10,6 +10,7 @@ import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -28,7 +29,7 @@ import javax.sql.DataSource;
  */
 
 @Configuration
-@EnableJpaRepositories(entityManagerFactoryRef = "entityManagerFactory", transactionManagerRef = "transactionManager")
+@EnableJpaRepositories(basePackages = {"com.hcs.repository"}, entityManagerFactoryRef = "entityManagerFactory", transactionManagerRef = "transactionManager")
 @MapperScan(basePackages = "com.hcs.mapper", sqlSessionFactoryRef = "SqlSessionFactory")
 public class DataSourceConfig {
 

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   datasource:
     hikari:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      #jdbc-url: "jdbc:mysql://localhost:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
+      # jdbc-url: "jdbc:mysql://localhost:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
       jdbc-url: "jdbc:mysql://49.50.175.87:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
       username: ENC(/vfTGzkQsvDmJGsLHCRGk8WaCVxqrAkS)
       password: ENC(/7M0dZ5y6e2xyeC2YPa3Jj7kqrJCYaCn)

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -17,7 +17,8 @@ spring:
   datasource:
     hikari:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: "jdbc:mysql://localhost:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
+      #jdbc-url: "jdbc:mysql://localhost:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
+      jdbc-url: "jdbc:mysql://49.50.175.87:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
       username: ENC(/vfTGzkQsvDmJGsLHCRGk8WaCVxqrAkS)
       password: ENC(/7M0dZ5y6e2xyeC2YPa3Jj7kqrJCYaCn)
   jpa:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   datasource:
     hikari:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      # jdbc-url: "jdbc:mysql://localhost:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
+      #jdbc-url: "jdbc:mysql://localhost:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
       jdbc-url: "jdbc:mysql://49.50.175.87:3306/HCS?serverTimezone=UTC&characterEncoding=UTF-8"
       username: ENC(/vfTGzkQsvDmJGsLHCRGk8WaCVxqrAkS)
       password: ENC(/7M0dZ5y6e2xyeC2YPa3Jj7kqrJCYaCn)

--- a/api/src/test/java/com/hcs/controller/ClubControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/ClubControllerTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -47,7 +46,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @EnableMockMvc
 @EnableEncryptableProperties
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 class ClubControllerTest {
 

--- a/api/src/test/java/com/hcs/controller/CommentControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/CommentControllerTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -38,7 +37,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @EnableMockMvc
 @EnableEncryptableProperties
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 public class CommentControllerTest {
 

--- a/api/src/test/java/com/hcs/controller/ExceptionAdvisorTest.java
+++ b/api/src/test/java/com/hcs/controller/ExceptionAdvisorTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -24,7 +23,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @EnableMockMvc
 @EnableEncryptableProperties
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 public class ExceptionAdvisorTest {
     @Autowired

--- a/api/src/test/java/com/hcs/controller/TradePostControllerTest.java
+++ b/api/src/test/java/com/hcs/controller/TradePostControllerTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -42,7 +41,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @EnableMockMvc
 @EnableEncryptableProperties
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 public class TradePostControllerTest {
 
@@ -418,7 +416,6 @@ public class TradePostControllerTest {
             assertThat(invalidFields).contains(field);
         }
     }
-
 
     @DisplayName("중고거래 글 삭제")
     @Test

--- a/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
+++ b/api/src/test/java/com/hcs/dto/ClubDtoValidationTest.java
@@ -23,7 +23,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @EnableMockMvc
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 class ClubDtoValidationTest {
 

--- a/api/src/test/java/com/hcs/service/CommentServiceTest.java
+++ b/api/src/test/java/com/hcs/service/CommentServiceTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @EnableEncryptableProperties
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 class CommentServiceTest {
 

--- a/api/src/test/java/com/hcs/service/TradePostServiceTest.java
+++ b/api/src/test/java/com/hcs/service/TradePostServiceTest.java
@@ -18,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @EnableEncryptableProperties
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 class TradePostServiceTest {
 

--- a/api/src/test/java/com/hcs/service/UserServiceTest.java
+++ b/api/src/test/java/com/hcs/service/UserServiceTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @EnableEncryptableProperties
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 class UserServiceTest {
 

--- a/api/src/test/java/com/hcs/setting/JpaWithMybatisTests.java
+++ b/api/src/test/java/com/hcs/setting/JpaWithMybatisTests.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @SpringBootTest
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 public class JpaWithMybatisTests {
 

--- a/api/src/test/java/com/hcs/validator/UserValidationTest.java
+++ b/api/src/test/java/com/hcs/validator/UserValidationTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +32,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @EnableMockMvc
 @EnableEncryptableProperties
-@EnableJpaRepositories(basePackages = {"com.hcs.repository"})
 @Transactional
 public class UserValidationTest {
 
@@ -42,7 +40,6 @@ public class UserValidationTest {
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
-
 
     @DisplayName("회원 가입 처리 - 입력값 오류 - @InitBinder 적용 안함")
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
         annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
         annotationProcessor 'org.projectlombok:lombok'
 
-        runtimeOnly 'mysql:mysql-connector-java:8.0.25'
+        runtimeOnly 'mysql:mysql-connector-java'
 
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
         annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
         annotationProcessor 'org.projectlombok:lombok'
 
-        runtimeOnly 'mysql:mysql-connector-java'
+        runtimeOnly 'mysql:mysql-connector-java:8.0.25'
 
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'


### PR DESCRIPTION
1. `@SpringBootApplication` 이 적용된 클래스에 있던 
`@EnableJpaRepositories` , `@MapperScan` 애노테이션을 관련 설정이 있는곳에 두기 위해 `DatasourceConfig.java` 로 옮겼습니다.

2. test 에서 사용하던 '@EnableJpaRepositories(basePackages = {"com.hcs.repository"})' 설정을 삭제하고  `DatasourceConfig.java` 에서 관련 설정을 가져오도록 변경했습니다.
3. cd/ci 설정을 위해 기본 db 설정을 원격 db 서버로 설정해두었습니다. 추후 profile 설정을 통해 local 과 product 환경을 나누도록 하겠습니다.
4. test code 실패 방지를 위해 임시로 `UserControllerTest.java`를 수정하였습니다. 기존 테스트는 미리 db에 데이터를 넣어야 실행되도록 되어있어 test 실패 방지를 위해 수정하였습니다. 확인해보시고 추후 수정 부탁드립니다.