### PR TITLE
Redis 를  HttpSession 저장소로 설정

### DIFF
--- a/api/src/main/java/com/hcs/config/RedisConfig.java
+++ b/api/src/main/java/com/hcs/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package com.hcs.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+/**
+ * @EnableRedisHttpSession : redis 를 HttpSession 저장소로 설정
+ */
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    public String host;
+
+    @Value("${spring.redis.port}")
+    public int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(connectionFactory);
+        return redisTemplate;
+    }
+}
+

--- a/api/src/main/java/com/hcs/domain/User.java
+++ b/api/src/main/java/com/hcs/domain/User.java
@@ -10,6 +10,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 /**
@@ -23,7 +24,7 @@ import java.time.LocalDateTime;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
+public class User implements Serializable {
 
     @EqualsAndHashCode.Include
     @Id

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -19,6 +19,13 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     main:
       allow-bean-definition-overriding: true
+
+  redis:
+    host: localhost
+    port: 6379
+  session:
+    store-type: redis
+
   security:
     oauth2:
       client:

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-test-autoconfigure:2.6.0'
         implementation 'org.springframework.boot:spring-boot-starter-cache'
         implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+        implementation 'org.springframework.session:spring-session-data-redis'
+        implementation 'io.lettuce:lettuce-core:6.1.6.RELEASE'
 
         implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.0'
         implementation 'org.webjars:stomp-websocket:2.3.4'


### PR DESCRIPTION
**Redis 를 HttpSession 저장소로 변경**

- redis 를 session 저장소로 사용하기 위한 종속성 추가
- redis session 관련 설정 RedisConfig 파일 및 `application.yml`  속성 추가
- redis 에 저장시 직렬화를 위해 User 도메인 객체에 *`Serializable`  인터페이스 상속*

