### PR TITLE
Spring actuator health check 설정 추가

### DIFF
--- a/api/src/main/java/com/hcs/config/SecurityConfig.java
+++ b/api/src/main/java/com/hcs/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.OPTIONS, "/*").permitAll()
                 .antMatchers("/login/oauth2/code/**").permitAll()
                 .antMatchers("/actuator/**").permitAll()
+                .antMatchers("/ex-health-check").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .formLogin()

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -62,6 +62,13 @@ management:
     web:
       exposure:
         include: health, info, prometheus
+      base-path: /
+      path-mapping:
+        health: ex-health-check
+  endpoint:
+    health:
+      show-details: always
+
 
 local:
   server:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -69,7 +69,6 @@ management:
     health:
       show-details: always
 
-
 local:
   server:
     port: 8080


### PR DESCRIPTION
**Spring actuator health check 설정 추가**

- 배포 서버의 shell script 에 설정된 url 로 health check 를 진행하기위해 health-check 관련  path 설정 추가

(기존 /actuator/health 에서 /ex-health-check 로 변경)

- health check 시에 좀더 자세한 정호를 위해 details 설정 추가