### PR TITLE
Fix session management security config

### DIFF
--- a/api/src/main/java/com/hcs/config/SecurityConfig.java
+++ b/api/src/main/java/com/hcs/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -122,5 +123,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .defaultSuccessUrl("/oauth2LoginSuccess").permitAll()
                 .userInfoEndpoint()
                 .userService(customOAuth2UserService);
+        
+        http.sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                .invalidSessionUrl("/login");
     }
 }


### PR DESCRIPTION
- `SecurityConfig` 에 빠진 `sessionManagement` 설정을 추가했습니다.
세션정책 설정과 잘못된 세션 id 일경우 login 페이지로 돌아가는 설정을 추가했습니다.